### PR TITLE
マイページからプロフィール画像アップロード 

### DIFF
--- a/web/friku/components/Button/index.stories.tsx
+++ b/web/friku/components/Button/index.stories.tsx
@@ -16,7 +16,7 @@ export default {
     },
     size: {
       description: "ボタンサイズ",
-      options: ["small", "medium", "large"],
+      options: ["small", "medium", "large", "full"],
       control: { type: "select" },
     },
     label: {

--- a/web/friku/components/Button/index.tsx
+++ b/web/friku/components/Button/index.tsx
@@ -1,7 +1,7 @@
 interface ButtonProps {
   primary?: boolean;
   backgroundColor?: string;
-  size?: "small" | "medium" | "large";
+  size?: "small" | "medium" | "large" | "full";
   label: string;
   onClick?: () => void;
 }
@@ -21,6 +21,8 @@ const Button: React.FC<ButtonProps> = ({
       ? "py-2 px-5 text-sm"
       : size === "large"
       ? "py-3 px-6 text-base"
+      : size === "full"
+      ? "w-full py-3 px-6"
       : "";
 
   return primary ? (

--- a/web/friku/components/Modal/CropModal/index.tsx
+++ b/web/friku/components/Modal/CropModal/index.tsx
@@ -1,0 +1,72 @@
+import ReactCrop from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
+import { Crop } from "react-image-crop";
+
+// Components
+import Button from "../../Button";
+
+// Types
+interface CropModalProps {
+  src: string;
+  crop: Crop;
+  onSelectFile: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onImageLoaded: (image: HTMLImageElement) => boolean | void;
+  onCropComplete: (crop: Crop) => void;
+  onCropChange: (crop: Crop) => void;
+  addProfileImage: () => void;
+}
+
+const CropModal: React.FC<CropModalProps> = ({
+  src,
+  crop,
+  onSelectFile,
+  onImageLoaded,
+  onCropComplete,
+  onCropChange,
+  addProfileImage,
+}) => {
+  return (
+    <div className="modal" id="cropModal">
+      <div className="modal-box bg-white max-w-4xl h-4/5">
+        <div className="w-full flex flex-col justify-center items-center px-4">
+          <div className="w-full">
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => onSelectFile(e)}
+            />
+            {src && (
+              <>
+                <ReactCrop
+                  src={src}
+                  crop={crop}
+                  ruleOfThirds
+                  onImageLoaded={onImageLoaded}
+                  onComplete={onCropComplete}
+                  onChange={onCropChange}
+                />
+              </>
+            )}
+
+            <div className="justify-center w-full mt-2">
+              <Button
+                primary={true}
+                size={"full"}
+                label={"アップロード"}
+                onClick={addProfileImage}
+              />
+              <label
+                htmlFor="cropModal"
+                className="w-full btn btn-outline btn-primary mt-3"
+              >
+                とじる
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CropModal;

--- a/web/friku/components/Profile/index.tsx
+++ b/web/friku/components/Profile/index.tsx
@@ -1,15 +1,18 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { Crop } from "react-image-crop";
 
 import axios from "axios";
 
-// icons
+// Components
+import CropModal from "../Modal/CropModal";
+
+// Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 
 export default function Profile({ user }) {
   const {
-    control,
     register,
     formState: { errors },
     handleSubmit,
@@ -37,25 +40,26 @@ export default function Profile({ user }) {
   };
 
   //画像アップロード
-  const [image, setImage] = useState(null);
-  const [src, setSrc] = useState(null);
+  const [image, setImage] = useState<string | null>(null);
+  const [src, setSrc] = useState<string | null>(null);
 
-  const [crop, setCrop] = useState({
+  const [crop, setCrop] = useState<Crop>({
     unit: "%",
     x: 25,
     y: 10,
     width: 80,
+    height: 80,
     aspect: 4 / 4,
   });
-  const [imageRef, setImageRef] = useState(null);
+  const [imageRef, setImageRef] = useState<HTMLImageElement | null>(null);
 
   // 画像読み込み
-  const onSelectFile = (e) => {
+  const onSelectFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     if (e.target.files !== null) {
       const reader = new FileReader();
       reader.addEventListener("load", () => {
-        setSrc(reader.result);
+        typeof reader.result === "string" && setSrc(reader.result);
       });
       reader.readAsDataURL(e.target.files[0]);
     }
@@ -106,7 +110,10 @@ export default function Profile({ user }) {
 
   const addProfileImage = async () => {
     await onCropComplete(crop);
-    document.querySelector("#cropModal").checked = false;
+    const ModalcheckBox = document.querySelector(
+      "#cropModal"
+    ) as HTMLInputElement;
+    ModalcheckBox.checked = false;
   };
 
   return (
@@ -134,7 +141,7 @@ export default function Profile({ user }) {
               </label>
             )}
             <input type="checkbox" id="cropModal" className="modal-toggle" />
-            {/* <CropModal
+            <CropModal
               src={src}
               crop={crop}
               onSelectFile={onSelectFile}
@@ -142,7 +149,7 @@ export default function Profile({ user }) {
               onCropComplete={onCropComplete}
               onCropChange={onCropChange}
               addProfileImage={addProfileImage}
-            /> */}
+            />
           </div>
           <div className="pl-6">
             <p className="text-3xl mb-3　">{user.name}</p>

--- a/web/friku/components/Profile/index.tsx
+++ b/web/friku/components/Profile/index.tsx
@@ -163,6 +163,28 @@ const Profile = ({ user, updateProfile }) => {
           <div className="w-full md:mb-0">
             <label
               className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
+              htmlFor="nameKana"
+            >
+              氏名（フリガナ）
+            </label>
+            <input
+              id="lastNameKana"
+              type="text"
+              defaultValue={user.last_name_kana}
+              className="hover:bg-gray-100 focus:bg-gray-100 focus:outline-none rounded py-3 px-4 mb-3 w-1/2"
+              {...register("lastNameKana", { required: true })}
+            />
+            <input
+              id="firstNameKana"
+              type="text"
+              defaultValue={user.first_name_kana}
+              className="hover:bg-gray-100 focus:bg-gray-100 focus:outline-none rounded py-3 px-4 mb-3 w-1/2"
+              {...register("firstNameKana", { required: true })}
+            />
+          </div>
+          <div className="w-full md:mb-0">
+            <label
+              className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
               htmlFor="email"
             >
               メールアドレス

--- a/web/friku/components/Profile/index.tsx
+++ b/web/friku/components/Profile/index.tsx
@@ -2,8 +2,6 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Crop } from "react-image-crop";
 
-import axios from "axios";
-
 // Components
 import CropModal from "../Modal/CropModal";
 
@@ -11,33 +9,12 @@ import CropModal from "../Modal/CropModal";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 
-export default function Profile({ user }) {
+const Profile = ({ user, updateProfile }) => {
   const {
     register,
     formState: { errors },
     handleSubmit,
   } = useForm();
-
-  const updateProfile = async (data) => {
-    // 画像ファイルで送信する可能性をふまえ、FormDataで送ってます
-    console.log(data, image);
-    const formData = new FormData();
-    formData.append("image", image);
-    formData.append("_method", "PUT");
-    console.log(formData.get("image"));
-
-    await axios
-      .post(`http://localhost/api/user/${user.id}/edit`, formData, {
-        headers: { "content-type": "multipart/form-data" },
-      })
-      .then((res) => {
-        console.log(res);
-      })
-      .catch((err) => {
-        console.log(err.response);
-        console.log("[login]ログイン失敗");
-      });
-  };
 
   //画像アップロード
   const [image, setImage] = useState<string | null>(null);
@@ -67,7 +44,6 @@ export default function Profile({ user }) {
 
   const onImageLoaded = (image) => {
     setImageRef(image);
-    console.log("ロード", imageRef);
   };
 
   // 画像くり抜き
@@ -102,7 +78,6 @@ export default function Profile({ user }) {
           crop.height
         );
       }
-      // base64にしてstate保存(仮)
       const base64Image = canvas.toDataURL("img/url");
       setImage(base64Image);
     }
@@ -121,7 +96,17 @@ export default function Profile({ user }) {
       <div className="w-3/4 bg-white mb-6">
         <div className="w-full flex px-10 py-6 md:mb-0">
           <div className="avatar placeholder">
-            {image ? (
+            {user.img_path ? (
+              <label
+                htmlFor="cropModal"
+                className="text-neutral-content rounded-full w-32 h-32 border"
+              >
+                <img
+                  src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/user.img_path`}
+                  style={{ borderRadius: "100%" }}
+                />
+              </label>
+            ) : image ? (
               <label
                 htmlFor="cropModal"
                 className="text-neutral-content rounded-full w-32 h-32 border"
@@ -140,6 +125,25 @@ export default function Profile({ user }) {
                 />
               </label>
             )}
+            {/* {image ? (
+              <label
+                htmlFor="cropModal"
+                className="text-neutral-content rounded-full w-32 h-32 border"
+              >
+                <img src={image} style={{ borderRadius: "100%" }} />
+              </label>
+            ) : (
+              <label
+                htmlFor="cropModal"
+                className="bg-neutral-focus text-neutral-content rounded-full w-32 h-32 hover:bg-primary"
+              >
+                <FontAwesomeIcon
+                  icon={faUser}
+                  size="lg"
+                  className="ml-14 mt-14"
+                />
+              </label>
+            )} */}
             <input type="checkbox" id="cropModal" className="modal-toggle" />
             <CropModal
               src={src}
@@ -161,7 +165,9 @@ export default function Profile({ user }) {
         </div>
       </div>
       <div className="w-3/4 bg-white px-10 py-6">
-        <form onSubmit={handleSubmit(updateProfile)}>
+        <form
+          onSubmit={handleSubmit((data) => updateProfile(data, user, image))}
+        >
           <div className="w-full md:mb-0">
             <label
               className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
@@ -207,4 +213,6 @@ export default function Profile({ user }) {
       </div>
     </>
   );
-}
+};
+
+export default Profile;

--- a/web/friku/components/Profile/index.tsx
+++ b/web/friku/components/Profile/index.tsx
@@ -137,13 +137,11 @@ const Profile = ({ user, updateProfile }) => {
         </div>
       </div>
       <div className="w-3/4 bg-white px-10 py-6">
-        <form
-          onSubmit={handleSubmit((data) => updateProfile(data, user, image))}
-        >
+        <form onSubmit={handleSubmit((data) => updateProfile(data, image))}>
           <div className="w-full md:mb-0">
             <label
-              className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-              htmlFor="email"
+              className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
+              htmlFor="name"
             >
               氏名
             </label>
@@ -164,7 +162,7 @@ const Profile = ({ user, updateProfile }) => {
           </div>
           <div className="w-full md:mb-0">
             <label
-              className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+              className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
               htmlFor="email"
             >
               メールアドレス
@@ -177,7 +175,36 @@ const Profile = ({ user, updateProfile }) => {
               {...register("email", { required: true })}
             />
           </div>
-
+          <div className="w-full md:mb-0">
+            <label
+              className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
+              htmlFor="birth"
+            >
+              生年月日
+            </label>
+            <input
+              disabled
+              id="birth"
+              type="text"
+              defaultValue={user.birth}
+              className="bg-white rounded py-3 px-4 mb-3 w-full"
+            />
+          </div>
+          <div className="w-full md:mb-0">
+            <label
+              className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
+              htmlFor="gender"
+            >
+              性別
+            </label>
+            <input
+              disabled
+              id="gender"
+              type="text"
+              defaultValue={user.gender === 1 ? "男性" : "女性"}
+              className="bg-white rounded py-3 px-4 mb-3 w-full"
+            />
+          </div>
           <button type="submit" className="w-full btn">
             変更する
           </button>

--- a/web/friku/components/Profile/index.tsx
+++ b/web/friku/components/Profile/index.tsx
@@ -96,17 +96,8 @@ const Profile = ({ user, updateProfile }) => {
       <div className="w-3/4 bg-white mb-6">
         <div className="w-full flex px-10 py-6 md:mb-0">
           <div className="avatar placeholder">
-            {user.img_path ? (
-              <label
-                htmlFor="cropModal"
-                className="text-neutral-content rounded-full w-32 h-32 border"
-              >
-                <img
-                  src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/user.img_path`}
-                  style={{ borderRadius: "100%" }}
-                />
-              </label>
-            ) : image ? (
+            {/* ユーザー情報の画像表示ができるようになったら分岐修正 */}
+            {image ? (
               <label
                 htmlFor="cropModal"
                 className="text-neutral-content rounded-full w-32 h-32 border"
@@ -125,25 +116,6 @@ const Profile = ({ user, updateProfile }) => {
                 />
               </label>
             )}
-            {/* {image ? (
-              <label
-                htmlFor="cropModal"
-                className="text-neutral-content rounded-full w-32 h-32 border"
-              >
-                <img src={image} style={{ borderRadius: "100%" }} />
-              </label>
-            ) : (
-              <label
-                htmlFor="cropModal"
-                className="bg-neutral-focus text-neutral-content rounded-full w-32 h-32 hover:bg-primary"
-              >
-                <FontAwesomeIcon
-                  icon={faUser}
-                  size="lg"
-                  className="ml-14 mt-14"
-                />
-              </label>
-            )} */}
             <input type="checkbox" id="cropModal" className="modal-toggle" />
             <CropModal
               src={src}

--- a/web/friku/contexts/Auth/index.js
+++ b/web/friku/contexts/Auth/index.js
@@ -120,12 +120,9 @@ const AuthProvider = ({ children }) => {
         first_name: firstName,
         email,
         imageBase64: image,
-        password: "",
       })
       .then((res) => {
-        console.log(res);
         if (res.status === 200) {
-          console.log(res.data);
           setUser(res.data);
         } else {
           console.log(res.data);

--- a/web/friku/contexts/Auth/index.js
+++ b/web/friku/contexts/Auth/index.js
@@ -112,15 +112,15 @@ const AuthProvider = ({ children }) => {
       });
   };
 
-  const updateProfile = async (data, user, image) => {
-    console.log("base64", image);
-    // 後々body内容変更
+  const updateProfile = async (data, image) => {
+    const { lastName, firstName, email } = data;
     await axios
       .put(`http://localhost/api/user/${user.id}/edit`, {
-        // last_name: data.lastName,
-        // first_name: data.firstName,
-        // email,
+        last_name: lastName,
+        first_name: firstName,
+        email,
         imageBase64: image,
+        password: "",
       })
       .then((res) => {
         console.log(res);

--- a/web/friku/contexts/Auth/index.js
+++ b/web/friku/contexts/Auth/index.js
@@ -113,11 +113,13 @@ const AuthProvider = ({ children }) => {
   };
 
   const updateProfile = async (data, image) => {
-    const { lastName, firstName, email } = data;
+    const { lastName, firstName, lastNameKana, firstNameKana, email } = data;
     await axios
       .put(`http://localhost/api/user/${user.id}/edit`, {
         last_name: lastName,
         first_name: firstName,
+        last_name_kana: lastNameKana,
+        first_name_kana: firstNameKana,
         email,
         imageBase64: image,
       })

--- a/web/friku/contexts/Auth/index.js
+++ b/web/friku/contexts/Auth/index.js
@@ -113,24 +113,26 @@ const AuthProvider = ({ children }) => {
   };
 
   const updateProfile = async (data, user, image) => {
-    console.log(data);
+    console.log("base64", image);
     // 後々body内容変更
     await axios
       .put(`http://localhost/api/user/${user.id}/edit`, {
-        last_name: data.lastName,
-        first_name: data.firstName,
-        email,
+        // last_name: data.lastName,
+        // first_name: data.firstName,
+        // email,
         imageBase64: image,
       })
       .then((res) => {
+        console.log(res);
         if (res.status === 200) {
+          console.log(res.data);
           setUser(res.data);
         } else {
           console.log(res.data);
           alert("更新失敗");
         }
       })
-      .catch((err) => console.log(err.response));
+      .catch((err) => console.log("更新失敗", err));
   };
 
   const addFrikuBookmark = async (e, user, jobId) => {
@@ -139,7 +141,6 @@ const AuthProvider = ({ children }) => {
       alert("お気に入り追加はログインが必要です");
       return;
     }
-
     await axios.get(process.env.NEXT_PUBLIC_API_AUTH_URL).then((response) => {
       axios
         .put(

--- a/web/friku/contexts/Auth/index.js
+++ b/web/friku/contexts/Auth/index.js
@@ -112,6 +112,27 @@ const AuthProvider = ({ children }) => {
       });
   };
 
+  const updateProfile = async (data, user, image) => {
+    console.log(data);
+    // 後々body内容変更
+    await axios
+      .put(`http://localhost/api/user/${user.id}/edit`, {
+        last_name: data.lastName,
+        first_name: data.firstName,
+        email,
+        imageBase64: image,
+      })
+      .then((res) => {
+        if (res.status === 200) {
+          setUser(res.data);
+        } else {
+          console.log(res.data);
+          alert("更新失敗");
+        }
+      })
+      .catch((err) => console.log(err.response));
+  };
+
   const addFrikuBookmark = async (e, user, jobId) => {
     e.preventDefault();
     if (!user) {
@@ -233,6 +254,7 @@ const AuthProvider = ({ children }) => {
         signup,
         login,
         logout,
+        updateProfile,
         addFrikuBookmark,
         deleteFrikuBookmark,
         addOmBookmark,

--- a/web/friku/package-lock.json
+++ b/web/friku/package-lock.json
@@ -15,6 +15,7 @@
         "@tailwindcss/typography": "^0.4.1",
         "@types/node": "^16.11.7",
         "@types/react": "^17.0.35",
+        "@types/react-image-crop": "^8.1.3",
         "axios": "^0.21.1",
         "daisyui": "^1.14.1",
         "microcms-js-sdk": "^2.0.0",
@@ -7315,6 +7316,14 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-image-crop": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react-image-crop/-/react-image-crop-8.1.3.tgz",
+      "integrity": "sha512-icfA+xMUQIp4/u525uNRKVZyHA/j8C1dp7yFWiGC6dqXSKXoUg5QhqUotrrzxY285LgQMgaWBRjQzXyeUAKUUA==",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -29361,6 +29370,14 @@
           "resolved": "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz",
           "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
         }
+      }
+    },
+    "@types/react-image-crop": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react-image-crop/-/react-image-crop-8.1.3.tgz",
+      "integrity": "sha512-icfA+xMUQIp4/u525uNRKVZyHA/j8C1dp7yFWiGC6dqXSKXoUg5QhqUotrrzxY285LgQMgaWBRjQzXyeUAKUUA==",
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-syntax-highlighter": {

--- a/web/friku/package-lock.json
+++ b/web/friku/package-lock.json
@@ -23,6 +23,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-hook-form": "^7.19.0",
+        "react-image-crop": "^9.0.5",
         "typescript": "^4.5.2"
       },
       "devDependencies": {
@@ -9849,7 +9850,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19518,6 +19518,17 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-9.0.5.tgz",
+      "integrity": "sha512-J5lbsBMI36GsbkRHXNEo95OjwpxfkUBrEl9Oxb7z5mDC7iamySXYKhkv9QoidkfmI9e8Vj7q3SgNCVfuZHQMQw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-inspector": {
@@ -31283,8 +31294,7 @@
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -38211,6 +38221,14 @@
       "resolved": "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.19.5.tgz",
       "integrity": "sha512-+M9gd0nWWASuEitf5PQGOGNElnHknzY3rGISrPDXwsOmZb7c/jyvkRUqk4OJXaZit1ZwesSv+EysttdAeFEfmw==",
       "requires": {}
+    },
+    "react-image-crop": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-9.0.5.tgz",
+      "integrity": "sha512-J5lbsBMI36GsbkRHXNEo95OjwpxfkUBrEl9Oxb7z5mDC7iamySXYKhkv9QoidkfmI9e8Vj7q3SgNCVfuZHQMQw==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
     },
     "react-inspector": {
       "version": "5.1.1",

--- a/web/friku/package.json
+++ b/web/friku/package.json
@@ -27,6 +27,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-hook-form": "^7.19.0",
+    "react-image-crop": "^9.0.5",
     "typescript": "^4.5.2"
   },
   "devDependencies": {

--- a/web/friku/package.json
+++ b/web/friku/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/typography": "^0.4.1",
     "@types/node": "^16.11.7",
     "@types/react": "^17.0.35",
+    "@types/react-image-crop": "^8.1.3",
     "axios": "^0.21.1",
     "daisyui": "^1.14.1",
     "microcms-js-sdk": "^2.0.0",

--- a/web/friku/pages/_app.tsx
+++ b/web/friku/pages/_app.tsx
@@ -1,4 +1,4 @@
-import "../styles/globals.css";
+import { AppProps } from "next/app";
 import "tailwindcss/tailwind.css";
 
 // Contexts
@@ -10,7 +10,7 @@ import { SearchConditionProvider } from "../contexts/SearchCondition";
 // Components
 import Layout from "../components/Layout";
 
-function MyApp({ Component, pageProps }) {
+function MyApp({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
       <AdminProvider>

--- a/web/friku/pages/mypage/index.tsx
+++ b/web/friku/pages/mypage/index.tsx
@@ -1,15 +1,17 @@
-import { useEffect, useContext, useState } from "react";
+import { useEffect, useContext, useState, MouseEventHandler } from "react";
 import { useRouter } from "next/router";
 import { AuthContext } from "../../contexts/Auth/index";
 
+// Components
+import Profile from "../../components/Profile";
+
+// Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser, faHeart, faFileAlt } from "@fortawesome/free-solid-svg-icons";
 
-import Profile from "../../components/Profile";
-
-const Mypage = () => {
+const Mypage: React.FC = () => {
   const [currentMenu, setCurrentMenu] = useState("profile");
-  const { user } = useContext(AuthContext);
+  const { user, updateProfile } = useContext(AuthContext);
   const router = useRouter();
 
   useEffect(() => {
@@ -61,7 +63,9 @@ const Mypage = () => {
         </button>
       </div>
       <div className="flex flex-col justify-center items-center w-10/12 bg-gray-100 p-10 rounded-lg">
-        {user && currentMenu === "profile" && <Profile user={user} />}
+        {user && currentMenu === "profile" && (
+          <Profile user={user} updateProfile={updateProfile} />
+        )}
       </div>
     </div>
   );

--- a/web/friku/yarn.lock
+++ b/web/friku/yarn.lock
@@ -9639,6 +9639,13 @@
   "resolved" "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.19.5.tgz"
   "version" "7.19.5"
 
+"react-image-crop@^9.0.5":
+  "integrity" "sha512-J5lbsBMI36GsbkRHXNEo95OjwpxfkUBrEl9Oxb7z5mDC7iamySXYKhkv9QoidkfmI9e8Vj7q3SgNCVfuZHQMQw=="
+  "resolved" "https://registry.npmjs.org/react-image-crop/-/react-image-crop-9.0.5.tgz"
+  "version" "9.0.5"
+  dependencies:
+    "clsx" "^1.1.1"
+
 "react-inspector@^5.1.0":
   "integrity" "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg=="
   "resolved" "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz"
@@ -9720,7 +9727,7 @@
     "use-composed-ref" "^1.0.0"
     "use-latest" "^1.0.0"
 
-"react@^0.14.0 || ^15.0.0 || ^16.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^16.13.1 || ^17.0.0", "react@^16.6.0 || ^17.0.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.4 || ^17.0.0", "react@^17.0.2", "react@>= 0.14.0", "react@>= 16.3.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.12.0", "react@>=16.3.0", "react@>=16.8.0", "react@>=16.x", "react@15.x || 16.x || 16.4.0-alpha.0911da3", "react@17.0.2":
+"react@^0.14.0 || ^15.0.0 || ^16.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^16.13.1 || ^17.0.0", "react@^16.6.0 || ^17.0.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.4 || ^17.0.0", "react@^17.0.2", "react@>= 0.14.0", "react@>= 16.3.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.12.0", "react@>=16.13.1", "react@>=16.3.0", "react@>=16.8.0", "react@>=16.x", "react@15.x || 16.x || 16.4.0-alpha.0911da3", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz"
   "version" "17.0.2"

--- a/web/friku/yarn.lock
+++ b/web/friku/yarn.lock
@@ -2627,6 +2627,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-image-crop@^8.1.3":
+  "integrity" "sha512-icfA+xMUQIp4/u525uNRKVZyHA/j8C1dp7yFWiGC6dqXSKXoUg5QhqUotrrzxY285LgQMgaWBRjQzXyeUAKUUA=="
+  "resolved" "https://registry.npmjs.org/@types/react-image-crop/-/react-image-crop-8.1.3.tgz"
+  "version" "8.1.3"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.5":
   "integrity" "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg=="
   "resolved" "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz"


### PR DESCRIPTION
## 内容
 - https://github.com/local-venture-group/Friku/issues/36#issue-1051796910
 - CropModalコンポーネント作成
 - TS化
 
## 動作確認
 - ライブラリ追加したので、`front`コンテナに入って`npm install`を実行してください。
 - ログイン後、マイページから画像アイコンをクリックして画像アップロードしてください。
 
<img width="1042" alt="スクリーンショット 2021-11-22 19 58 27" src="https://user-images.githubusercontent.com/65808877/142849920-8131201c-bbcc-48fa-8caa-e0cbb7e89866.png">

プロフィール画像に表示されることを確認して、更新ボタンをクリックしてください。
<img width="1143" alt="スクリーンショット 2021-11-22 19 59 01" src="https://user-images.githubusercontent.com/65808877/142849956-d2c9f9c0-9d3b-4078-a3c7-b62dccfcf909.png">
 