### PR TITLE
検索モーダルアラート解消 #75

### DIFF
--- a/web/friku/components/Card/SearchTypeCard/index.tsx
+++ b/web/friku/components/Card/SearchTypeCard/index.tsx
@@ -5,7 +5,13 @@ import JobSearchModal from "../../Modal/JobSearchModal";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMapMarkerAlt, faSuitcase } from "@fortawesome/free-solid-svg-icons";
 
-export default function SearchTypeCard({ text }) {
+// Type
+interface SearchTypeCardProps {
+  text: string;
+}
+const SearchTypeCard = (props: SearchTypeCardProps) => {
+  const { text } = props;
+
   return (
     <>
       <label
@@ -41,4 +47,6 @@ export default function SearchTypeCard({ text }) {
       <JobSearchModal current={`${text === "勤務地" ? "location" : "type"}`} />
     </>
   );
-}
+};
+
+export default SearchTypeCard;

--- a/web/friku/components/Header/index.tsx
+++ b/web/friku/components/Header/index.tsx
@@ -18,7 +18,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 export default function Header() {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState<Boolean>(false);
   const { user, logout } = useContext(AuthContext);
 
   return (
@@ -179,7 +179,7 @@ export default function Header() {
               id="mobileSearchModal"
               className="modal-toggle"
             />
-            <MobileSearchModal />
+            <MobileSearchModal current={"location"} />
           </div>
         </div>
       </div>

--- a/web/friku/components/Modal/JobSearchModal/KeyWordTab/index.tsx
+++ b/web/friku/components/Modal/JobSearchModal/KeyWordTab/index.tsx
@@ -1,8 +1,16 @@
+import { UseFormRegister, FieldValues } from "react-hook-form";
+
 // Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faKey } from "@fortawesome/free-solid-svg-icons";
 
-export default function KeywordTab({ register }) {
+// Type
+interface TabProps {
+  register: UseFormRegister<FieldValues>;
+}
+
+export const KeyWordTab = (props: TabProps) => {
+  const { register } = props;
   return (
     <div className="w-full">
       <input
@@ -28,4 +36,6 @@ export default function KeywordTab({ register }) {
       </div>
     </div>
   );
-}
+};
+
+export default KeyWordTab;

--- a/web/friku/components/Modal/JobSearchModal/WorkLocationTab/index.tsx
+++ b/web/friku/components/Modal/JobSearchModal/WorkLocationTab/index.tsx
@@ -1,9 +1,17 @@
 import { useContext } from "react";
+import { UseFormRegister, FieldValues } from "react-hook-form";
 
 // Context
 import { SearchConditionContext } from "../../../../contexts/SearchCondition";
 
-export default function WorkLocationTab({ register }) {
+// Type
+interface TabProps {
+  register: UseFormRegister<FieldValues>;
+  modalSize: string;
+}
+
+const WorkLocationTab = (props: TabProps) => {
+  const { register, modalSize } = props;
   const { workLocations } = useContext(SearchConditionContext);
 
   if (!workLocations) return null;
@@ -13,7 +21,7 @@ export default function WorkLocationTab({ register }) {
         <div key={index} className="mb-3">
           <label className="cursor-pointer label justify-start bg-primary">
             <input
-              id={`area-${index}`}
+              id={`area-${modalSize}-${index}`}
               type="checkbox"
               className="checkbox checkbox-xs bg-white"
               value={location.area}
@@ -43,4 +51,6 @@ export default function WorkLocationTab({ register }) {
       ))}
     </div>
   );
-}
+};
+
+export default WorkLocationTab;

--- a/web/friku/components/Modal/JobSearchModal/WorkTypeTab/index.tsx
+++ b/web/friku/components/Modal/JobSearchModal/WorkTypeTab/index.tsx
@@ -1,9 +1,17 @@
 import { useContext } from "react";
+import { UseFormRegister, FieldValues } from "react-hook-form";
 
 // Context
 import { SearchConditionContext } from "../../../../contexts/SearchCondition";
 
-export default function WorkTypeTab({ register }) {
+// Type
+interface TabProps {
+  register: UseFormRegister<FieldValues>;
+  modalSize: string;
+}
+
+const WorkTypeTab = (props: TabProps) => {
+  const { register, modalSize } = props;
   const { workTypes } = useContext(SearchConditionContext);
   if (!workTypes) return null;
 
@@ -13,7 +21,9 @@ export default function WorkTypeTab({ register }) {
         <div key={i} className="w-1/2 lg:w-full">
           <label className="cursor-pointer label justify-start">
             <input
-              id={`${type === "勤務地" ? "location" : "workType"}-${i}`}
+              id={`${
+                type === "勤務地" ? "location" : "workType"
+              }-${modalSize}-${i}`}
               type="checkbox"
               value={i}
               {...register("workType")}
@@ -24,4 +34,6 @@ export default function WorkTypeTab({ register }) {
       ))}
     </div>
   );
-}
+};
+
+export default WorkTypeTab;

--- a/web/friku/components/Modal/JobSearchModal/index.tsx
+++ b/web/friku/components/Modal/JobSearchModal/index.tsx
@@ -6,9 +6,9 @@ import { useForm } from "react-hook-form";
 import { SearchConditionContext } from "../../../contexts/SearchCondition";
 
 // Component
-import KeyWordTab from "../JobSearchModal/KeyWordTab";
-import WorkTypeTab from "../JobSearchModal/WorkTypeTab";
-import WorkLocationTab from "../JobSearchModal/WorkLocationTab";
+import KeyWordTab from "./KeyWordTab";
+import WorkTypeTab from "./WorkTypeTab";
+import WorkLocationTab from "./WorkLocationTab";
 
 // Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -18,8 +18,14 @@ import {
   faPencilAlt,
 } from "@fortawesome/free-solid-svg-icons";
 
-const MobileSearchModal = () => {
-  const [currentTab, setCurrentTab] = useState("location");
+// Types
+interface JobSearchModalProps {
+  current: string;
+}
+
+const JobSearchModal = (props: JobSearchModalProps) => {
+  const { current } = props;
+  const [currentTab, setCurrentTab] = useState(current);
   const router = useRouter();
   const {
     register,
@@ -43,19 +49,22 @@ const MobileSearchModal = () => {
         ? data.workType.map((type) => parseInt(type))
         : [],
     });
-    document.querySelector("#mobileSearchModal").checked = false;
+    const modalCheck = document.querySelector(
+      "#jobSearchModal"
+    ) as HTMLInputElement;
+    modalCheck.checked = false;
     router.push("/job");
   };
 
   return (
-    <div className="modal" id="mobileSearchModal">
+    <div className="modal" id="jobSearchModal">
       <div className="modal-box h-screen w-full lg:max-w-3xl lg:h-4/5">
         <div className="w-full flex flex-col justify-center items-center px-4">
           <div className="w-full">
             <button
               type="button"
               id="location"
-              className={`text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
+              className={`text-2xl text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
                 currentTab === "location" && "text-gray-900 bg-blue-50"
               }`}
               onClick={handleClickTab}
@@ -63,21 +72,21 @@ const MobileSearchModal = () => {
               <FontAwesomeIcon
                 icon={faMapMarkerAlt}
                 className="text-primary mr-2"
-                size="sm"
+                size="lg"
               />
               勤務地
             </button>
             <button
               type="button"
               id="type"
-              className={`text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
+              className={`text-2xl text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
                 currentTab === "type" && "text-gray-900 bg-blue-50"
               }`}
               onClick={handleClickTab}
             >
               <FontAwesomeIcon
                 icon={faSuitcase}
-                size="sm"
+                size="lg"
                 className="text-primary mr-2"
               />
               職種
@@ -85,28 +94,30 @@ const MobileSearchModal = () => {
             <button
               type="button"
               id="word"
-              className={`text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
+              className={`text-2xl text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
                 currentTab === "word" && "text-gray-900 bg-blue-50"
               }`}
               onClick={handleClickTab}
             >
               <FontAwesomeIcon
                 icon={faPencilAlt}
-                size="sm"
+                size="lg"
                 className="text-primary mr-2"
               />
-              ワード
+              キーワード
             </button>
           </div>
           <form onSubmit={handleSubmit(onSubmit)} className="w-full">
             <div
-              className="w-full bg-blue-50 p-3 rounded-b-lg border-primary border-r-4 border-l-4 border-b-4 flex flex-col items-center"
-              style={{ height: "24rem" }}
+              className="w-full bg-blue-50 lg:p-10 rounded-b-lg border-primary border-r-4 border-l-4 border-b-4 flex flex-col items-center"
+              style={{ height: "32rem" }}
             >
               {currentTab === "location" && (
-                <WorkLocationTab register={register} />
+                <WorkLocationTab register={register} modalSize={"lg"} />
               )}
-              {currentTab === "type" && <WorkTypeTab register={register} />}
+              {currentTab === "type" && (
+                <WorkTypeTab register={register} modalSize={"lg"} />
+              )}
               {currentTab === "word" && <KeyWordTab register={register} />}
             </div>
             <button type="submit" className="w-full btn btn-primary mt-8">
@@ -115,7 +126,7 @@ const MobileSearchModal = () => {
           </form>
           <div className="justify-center w-full mt-2">
             <label
-              htmlFor="mobileSearchModal"
+              htmlFor="jobSearchModal"
               className="w-full btn btn-outline btn-primary"
             >
               とじる
@@ -127,4 +138,4 @@ const MobileSearchModal = () => {
   );
 };
 
-export default MobileSearchModal;
+export default JobSearchModal;

--- a/web/friku/components/Modal/JobSearchModal/index.tsx
+++ b/web/friku/components/Modal/JobSearchModal/index.tsx
@@ -23,6 +23,12 @@ interface JobSearchModalProps {
   current: string;
 }
 
+interface FormValue {
+  locations: [string] | null;
+  keywords: [string] | null;
+  workType: [string] | null;
+}
+
 const JobSearchModal = (props: JobSearchModalProps) => {
   const { current } = props;
   const [currentTab, setCurrentTab] = useState(current);
@@ -31,7 +37,7 @@ const JobSearchModal = (props: JobSearchModalProps) => {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm();
+  } = useForm<FormValue>();
   const { addSearchCondition } = useContext(SearchConditionContext);
 
   const handleClickTab = (e) => {

--- a/web/friku/components/Modal/MobileSearchModal/index.tsx
+++ b/web/friku/components/Modal/MobileSearchModal/index.tsx
@@ -23,6 +23,12 @@ interface MobileJobSearchModalProps {
   current: string;
 }
 
+interface FormValue {
+  locations: [string] | null;
+  keywords: [string] | null;
+  workType: [string] | null;
+}
+
 const MobileSearchModal = (props: MobileJobSearchModalProps) => {
   const { current } = props;
   const [currentTab, setCurrentTab] = useState(current);
@@ -31,7 +37,7 @@ const MobileSearchModal = (props: MobileJobSearchModalProps) => {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm();
+  } = useForm<FormValue>();
   const { addSearchCondition } = useContext(SearchConditionContext);
 
   const handleClickTab = (e) => {

--- a/web/friku/components/Modal/MobileSearchModal/index.tsx
+++ b/web/friku/components/Modal/MobileSearchModal/index.tsx
@@ -6,9 +6,9 @@ import { useForm } from "react-hook-form";
 import { SearchConditionContext } from "../../../contexts/SearchCondition";
 
 // Component
-import KeyWordTab from "./KeyWordTab";
-import WorkTypeTab from "./WorkTypeTab";
-import WorkLocationTab from "./WorkLocationTab";
+import KeyWordTab from "../JobSearchModal/KeyWordTab";
+import WorkTypeTab from "../JobSearchModal/WorkTypeTab";
+import WorkLocationTab from "../JobSearchModal/WorkLocationTab";
 
 // Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -18,7 +18,13 @@ import {
   faPencilAlt,
 } from "@fortawesome/free-solid-svg-icons";
 
-export default function JobSearchModal({ current }) {
+// Types
+interface MobileJobSearchModalProps {
+  current: string;
+}
+
+const MobileSearchModal = (props: MobileJobSearchModalProps) => {
+  const { current } = props;
   const [currentTab, setCurrentTab] = useState(current);
   const router = useRouter();
   const {
@@ -43,19 +49,22 @@ export default function JobSearchModal({ current }) {
         ? data.workType.map((type) => parseInt(type))
         : [],
     });
-    document.querySelector("#jobSearchModal").checked = false;
+    const modalCheck = document.querySelector(
+      "#jobSearchModal"
+    ) as HTMLInputElement;
+    modalCheck.checked = false;
     router.push("/job");
   };
 
   return (
-    <div className="modal" id="jobSearchModal">
+    <div className="modal" id="mobileSearchModal">
       <div className="modal-box h-screen w-full lg:max-w-3xl lg:h-4/5">
         <div className="w-full flex flex-col justify-center items-center px-4">
           <div className="w-full">
             <button
               type="button"
               id="location"
-              className={`text-2xl text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
+              className={`text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
                 currentTab === "location" && "text-gray-900 bg-blue-50"
               }`}
               onClick={handleClickTab}
@@ -63,21 +72,21 @@ export default function JobSearchModal({ current }) {
               <FontAwesomeIcon
                 icon={faMapMarkerAlt}
                 className="text-primary mr-2"
-                size="lg"
+                size="sm"
               />
               勤務地
             </button>
             <button
               type="button"
               id="type"
-              className={`text-2xl text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
+              className={`text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
                 currentTab === "type" && "text-gray-900 bg-blue-50"
               }`}
               onClick={handleClickTab}
             >
               <FontAwesomeIcon
                 icon={faSuitcase}
-                size="lg"
+                size="sm"
                 className="text-primary mr-2"
               />
               職種
@@ -85,28 +94,30 @@ export default function JobSearchModal({ current }) {
             <button
               type="button"
               id="word"
-              className={`text-2xl text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
+              className={`text-gray-400 py-4 w-1/3 rounded-t-lg border-primary border-t-4 border-r-4 border-l-4 hover:text-primary ${
                 currentTab === "word" && "text-gray-900 bg-blue-50"
               }`}
               onClick={handleClickTab}
             >
               <FontAwesomeIcon
                 icon={faPencilAlt}
-                size="lg"
+                size="sm"
                 className="text-primary mr-2"
               />
-              キーワード
+              ワード
             </button>
           </div>
           <form onSubmit={handleSubmit(onSubmit)} className="w-full">
             <div
-              className="w-full bg-blue-50 lg:p-10 rounded-b-lg border-primary border-r-4 border-l-4 border-b-4 flex flex-col items-center"
-              style={{ height: "32rem" }}
+              className="w-full bg-blue-50 p-3 rounded-b-lg border-primary border-r-4 border-l-4 border-b-4 flex flex-col items-center"
+              style={{ height: "24rem" }}
             >
               {currentTab === "location" && (
-                <WorkLocationTab register={register} />
+                <WorkLocationTab register={register} modalSize={"sm"} />
               )}
-              {currentTab === "type" && <WorkTypeTab register={register} />}
+              {currentTab === "type" && (
+                <WorkTypeTab register={register} modalSize={"sm"} />
+              )}
               {currentTab === "word" && <KeyWordTab register={register} />}
             </div>
             <button type="submit" className="w-full btn btn-primary mt-8">
@@ -115,7 +126,7 @@ export default function JobSearchModal({ current }) {
           </form>
           <div className="justify-center w-full mt-2">
             <label
-              htmlFor="jobSearchModal"
+              htmlFor="mobileSearchModal"
               className="w-full btn btn-outline btn-primary"
             >
               とじる
@@ -125,4 +136,6 @@ export default function JobSearchModal({ current }) {
       </div>
     </div>
   );
-}
+};
+
+export default MobileSearchModal;

--- a/web/friku/pages/login/index.tsx
+++ b/web/friku/pages/login/index.tsx
@@ -10,11 +10,17 @@ import { AuthContext } from "../../contexts/Auth";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
+// Types
+interface FormValues {
+  email: string;
+  password: string;
+}
+
 const logIn = () => {
   const router = useRouter();
-  const { register, handleSubmit } = useForm();
+  const { register, handleSubmit } = useForm<FormValues>();
   const { user, login } = useContext(AuthContext);
-  const [isRevealPassword, setIsRevealPassword] = useState(false);
+  const [isRevealPassword, setIsRevealPassword] = useState<Boolean>(false);
 
   const togglePassword = () => {
     setIsRevealPassword((prevState) => !prevState);


### PR DESCRIPTION
## 内容
 - https://github.com/local-venture-group/Friku/issues/75#issue-1061955747
 - PC版とモバイル版の勤務地タブ、職種タブの選択肢idに`modalSize`追加でID重複解消
 - 各コンポーネントTS化
 
## 動作確認
Headerの求人をさがすボタンまたはindexの勤務地/職種カードをクリックしてモーダルが表示されれば動作確認完了です。
![スクリーンショット 2021-11-24 17 38 46](https://user-images.githubusercontent.com/65808877/143204322-19d57813-c035-4753-95dd-793f2fc14da4.png)

