### PR TITLE
updateProfileエラー解消 #83

### DIFF
--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -90,7 +90,7 @@ class UserController extends Controller
     public function update(UserUpdateRequest $request, User $user, ImageService $imageService)
     {
 
-
+        $filePath = $user->img_path;
         $folderName = 'users';
         if($request->has('imageBase64')){
             $request->validate([

--- a/web/friku/components/Profile/index.tsx
+++ b/web/friku/components/Profile/index.tsx
@@ -137,7 +137,7 @@ const Profile = ({ user, updateProfile }) => {
         </div>
       </div>
       <div className="w-3/4 bg-white px-10 py-6">
-        <form onSubmit={handleSubmit((data) => updateProfile(data, image))}>
+        <form onSubmit={handleSubmit((data) => updateProfile({ data, image }))}>
           <div className="w-full md:mb-0">
             <label
               className="block tracking-wide text-gray-700 text-xs font-bold mb-2"

--- a/web/friku/contexts/Auth/index.tsx
+++ b/web/friku/contexts/Auth/index.tsx
@@ -52,7 +52,7 @@ interface UpdateProfileProps {
     lastNameKana: string;
     email: string;
   };
-  image: string;
+  image?: string;
 }
 
 interface BookmarkProps {


### PR DESCRIPTION
## 内容
 - https://github.com/local-venture-group/Friku/issues/83#issue-1062223204
 - propsを単一のオブジェクトへ修正
 
## 動作確認
 - `http://localhost/mypage`でプロフィール編集し、変更するボタンをクリック
 - 画像データなしの場合は500エラーになるようです
![スクリーンショット 2021-11-24 19 12 03](https://user-images.githubusercontent.com/65808877/143218719-3f2a0a13-0528-421d-9a18-44f19ae4031f.png)
 