### PR TITLE
fixUserRegister

### DIFF
--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -50,12 +50,13 @@ class UserController extends Controller
     }
     public function register(UserRequest $request, User $user)
     {
-
         $user = User::create([
             'name' => $request->lastName . ' ' . $request->firstName,
-            'firstName' => $request->firstName,
-            'lastName' => $request->lastName,
+            'first_name' => $request->firstName,
+            'last_name' => $request->lastName,
             'birth' => $request->birth,
+            'first_name_kana' => $request->firstNameKana,
+            'last_name_kana' => $request->lastNameKana,
             'gender' => $request->gender,
             'email' => $request->email,
             'password' => Hash::make($request->password),

--- a/api/app/Http/Requests/UserRequest.php
+++ b/api/app/Http/Requests/UserRequest.php
@@ -25,13 +25,12 @@ class UserRequest extends FormRequest
     {
 
         return [
-            'first_name' => 'required|string|max:191',
-            'last_name' => 'required|string|max:191',
+            'firstName' => 'required|string|max:191',
+            'lastName' => 'required|string|max:191',
             'email' => 'required|string|max:191|unique:users,email',
             'password' => 'required|string',
             'birth' => 'required|date',
             'gender' => 'integer|digits_between:1,2',
-            // 'image' => 'image|mimes:jpg,jpeg,png|max:2048',
         ];
     }
 }

--- a/web/friku/contexts/Auth/index.tsx
+++ b/web/friku/contexts/Auth/index.tsx
@@ -99,6 +99,8 @@ const AuthProvider = (props: AppProviderProps) => {
       .post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/user/register`, {
         firstName,
         lastName,
+        firstNameKana,
+        lastNameKana,
         email,
         birth,
         gender,


### PR DESCRIPTION
## 内容
 - https://github.com/local-venture-group/Sugnee/issues/93
 - サーバーサイド UserRequestクラスのバリデーション,UserControllerのregister内のカラム名の指定を変更
 - フロントエンド `friku/contexts/Auth/index.tsx`内の axios.postに firstNameKanaと、lastNameKanaを追加しておきました。

## 動作確認
- `localhost/signup/`にアクセス、フォームを入力し,入力内容確認ボタンをクリック
- 遷移先で登録をクリックして、 `localhost/signup/success` に遷移したら動作確認終了です。

今日もありがとうございます！
<img width="1372" alt="スクリーンショット 2021-11-25 20 22 38" src="https://user-images.githubusercontent.com/61079243/143442881-46f99e74-5b60-4ac4-a6b1-6e8917290457.png">


<img width="1228" alt="スクリーンショット 2021-11-25 21 37 03" src="https://user-images.githubusercontent.com/61079243/143443131-deb8e2f6-2086-4d8e-b2d2-f6a847c13a9d.png">
