### PR TITLE
add: apiの修正、注目記事系のテーブル追加、テストデータの投入, ディレクトリの移動

### DIFF
--- a/api/app/Http/Controllers/Api/User/Friku/FrikuJobsController.php
+++ b/api/app/Http/Controllers/Api/User/Friku/FrikuJobsController.php
@@ -11,13 +11,25 @@ use Illuminate\Http\Request;
 
 class FrikuJobsController extends Controller
 {
+
     //企業の求人一覧を取得
     public function pickUpCompanyJoboffers(FrikuCompany $frikuCompany)
     {
-
+        if(!$frikuCompany->is_pickup){
+            return response()->json(['message' => 'pickUp企業の求人ではありません']);
+        }
         $pickUpCompany = $frikuCompany->with('frikuJoboffers')->first();
         $pickUpJobs =  $pickUpCompany->frikuJoboffers;
         return JobResource::collection($pickUpJobs)->toJson();
         // return collect(new JobResource($pickUpJobs));
+    }
+    public function featureCompanyJoboffers(FrikuCompany $frikuCompany)
+    {
+        if($frikuCompany->is_pickup){
+            return response()->json(['message' => '注目企業の求人ではありません']);
+        }
+        $pickUpCompany = $frikuCompany->with('frikuJoboffers')->first();
+        $pickUpJobs =  $pickUpCompany->frikuJoboffers;
+        return JobResource::collection($pickUpJobs)->toJson();
     }
 }

--- a/api/app/Http/Controllers/Api/User/Friku/FrikuJobsController.php
+++ b/api/app/Http/Controllers/Api/User/Friku/FrikuJobsController.php
@@ -25,11 +25,12 @@ class FrikuJobsController extends Controller
     }
     public function featureCompanyJoboffers(FrikuCompany $frikuCompany)
     {
+
         if($frikuCompany->is_pickup){
             return response()->json(['message' => '注目企業の求人ではありません']);
         }
-        $pickUpCompany = $frikuCompany->with('frikuJoboffers')->first();
-        $pickUpJobs =  $pickUpCompany->frikuJoboffers;
-        return JobResource::collection($pickUpJobs)->toJson();
+        $featureCompany = $frikuCompany->with('frikuJoboffers')->first();
+        $featureJobs =  $featureCompany->frikuJoboffers;
+        return JobResource::collection($featureJobs)->toJson();
     }
 }

--- a/api/app/Http/Controllers/Api/User/JobSearchesController.php
+++ b/api/app/Http/Controllers/Api/User/JobSearchesController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api\User;
+
+use App\Consts\JobConditionConsts;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JobResource;
+use App\Job\UseCase\SearchJoboffersCrawledUseCase;
+use App\Job\UseCase\SearchJoboffersOmOriginalUseCase;
+use App\Services\JobService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class JobSearchesController extends Controller
+{
+    public function searchJobOffers(Request $request)
+    {
+        $this->limit = 10;
+        //ダイエット
+        if (!(empty($request->query() || empty(Auth::guard('users'))))) {
+            //ここにユーザーの検索条件を保存する処理を書く(メソッドを作り呼び出す)
+        }
+
+        //OM求人(独自)取得
+        $useCase = new SearchJoboffersOmOriginalUseCase();
+        $omOriginalJoboffers = $useCase->handle($request, $this->limit);
+
+        //OM求人(ハロワ、indeed)取得
+        $useCase = new SearchJoboffersCrawledUseCase();
+        $omCrawledJoboffers = $useCase->handle($request, $this->limit);
+
+
+        $mergeOmJoboffers = $omOriginalJoboffers->merge($omCrawledJoboffers);
+
+        return JobResource::collection($mergeOmJoboffers)->toJson();
+    }
+    public function getConditions(JobService $jobService)
+    {
+        return [
+            'city' => $jobService->getJobConditions(),
+            'work_type' => JobConditionConsts::WORK_TYPES,
+        ];
+    }
+}

--- a/api/app/Http/Controllers/Api/User/OwnedMaker/JobsController.php
+++ b/api/app/Http/Controllers/Api/User/OwnedMaker/JobsController.php
@@ -31,27 +31,7 @@ class JobsController extends Controller
         //ここで、応募済かどうかを取得する。
         return collect(new JobResource($corporationJoboffer));
     }
-    public function searchJobOffers(Request $request)
-    {
-        $this->limit = 10;
-        //ダイエット
-        if (!(empty($request->query() || empty(Auth::guard('users'))))) {
-            //ここにユーザーの検索条件を保存する処理を書く(メソッドを作り呼び出す)
-        }
 
-        //OM求人(独自)取得
-        $useCase = new SearchJoboffersOmOriginalUseCase();
-        $omOriginalJoboffers = $useCase->handle($request, $this->limit);
-
-        //OM求人(ハロワ、indeed)取得
-        $useCase = new SearchJoboffersCrawledUseCase();
-        $omCrawledJoboffers = $useCase->handle($request, $this->limit);
-
-
-        $mergeOmJoboffers = $omOriginalJoboffers->merge($omCrawledJoboffers);
-
-        return JobResource::collection($mergeOmJoboffers)->toJson();
-    }
     public function getConditions(JobService $jobService)
     {
         return [

--- a/api/app/Http/Controllers/Api/User/PagesController.php
+++ b/api/app/Http/Controllers/Api/User/PagesController.php
@@ -19,15 +19,9 @@ class PagesController extends Controller
 {
     public function top()
     {
-        // dd(Storage::files('public/users/'));
-        // dd(Storage::disk('public')->path('22c128fd377344cad5f35dd5184257b8.png'));
-        // dd(Storage::disk('public')->url('22c128fd377344cad5f35dd5184257b8.png'));
         //TODO: 2種類のデータを返す
 
         //     ②注目記事一覧
-        //     ③OM独自求人
-        // $omCrawledUseCase = new GetOmJobofferCrawledUseCase();
-        // $omCrawledJoboffers = $omCrawledUseCase->handle();
 
         //TODO: ここも、配列はそのうち一つにまとめる？　typeもつける？
         $omOriginalUseCase = new GetOmJobofferOriginalUseCase();

--- a/api/app/Models/FeaturedArticleContent.php
+++ b/api/app/Models/FeaturedArticleContent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FeaturedArticleContent extends Model
+{
+    use HasFactory;
+    protected $fillable = [
+        'featured_company_article_id',
+        'subTitle',
+        'image1',
+        'image1Caption',
+        'image2',
+        'image2Caption',
+        'body'
+    ];
+    public function featuredCompanyArticle()
+    {
+        return $this->belongsTo(FeaturedCompanyArticle::class);
+    }
+}

--- a/api/app/Models/FeaturedCompanyArticle.php
+++ b/api/app/Models/FeaturedCompanyArticle.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\FrikuCompany;
+use App\Models\FeaturedArticleContent;
+class FeaturedCompanyArticle extends Model
+{
+    use HasFactory;
+    protected $connection = 'fukuriku';
+    protected $guarded = [
+        'id',
+    ];
+    public function frikuCompany()
+    {
+        return $this->belongsTo(FrikuCompany::class, 'company_id');
+    }
+    public function featuredArticleContent()
+    {
+        return $this->hasMany(FeaturedArticleContent::class, 'featured_company_article_id');
+    }
+}

--- a/api/app/Models/FrikuCompany.php
+++ b/api/app/Models/FrikuCompany.php
@@ -20,4 +20,8 @@ class FrikuCompany extends Model
     {
         return $this->hasMany(FrikuJoboffer::class, 'company_id');
     }
+    public function featuredCompanyArticle()
+    {
+        return $this->hasOne(FeaturedCompanyArticle::class);
+    }
 }

--- a/api/database/migrations/2021_11_29_132036_create_featured_company_articles_table.php
+++ b/api/database/migrations/2021_11_29_132036_create_featured_company_articles_table.php
@@ -1,0 +1,91 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFeaturedCompanyArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('featured_company_articles', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->timestamp('published_at')->nullable();
+            $table->boolean('is_released');
+            $table->foreignId('friku_company_id')->constrained()
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+            $table->string('title');
+            $table->string('thumbnail_url')->nullable();
+            $table->integer('thumbnail_height')->nullable();
+            $table->integer('thumbnail_width')->nullable();
+
+            // export interface featuredCompanyArticle {
+            //     id: string;
+            //     createdAt: Date;
+            //     updatedAt: Date;
+            //     publishedAt: Date;
+            //     isReleased: boolean;
+            //     companyId: number;  => returnする際はここに企業データ入るイメージ
+            //     title: string;
+            //     thumbnail: {
+            //       url: string;
+            //       height: number;
+            //       width: number;
+            //     };
+            //     body: {
+            //       contents1: {
+            //         subTitle: string;
+            //         image1: string;
+            //         image1Caption: string;
+            //         image2: string;
+            //         image2Caption: string;
+            //         body: string;
+            //       }
+            //       contents2: {
+            //         subTitle: string;
+            //         image1: string;
+            //         image1Caption: string;
+            //         image2: string;
+            //         image2Caption: string;
+            //         body: string;
+            //       }
+            //       contents3: {
+            //         subTitle: string;
+            //         image1: string;
+            //         image1Caption: string;
+            //         image2: string;
+            //         image2Caption: string;
+            //         body: string;
+            //       }
+            //       contents4: {
+            //         subTitle: string;
+            //         image1: string;
+            //         image1Caption: string;
+            //         image2: string;
+            //         image2Caption: string;
+            //         body: string;
+            //       }
+            //     }
+            //   }
+
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('featured_company_articles');
+    }
+}

--- a/api/database/migrations/2021_11_29_134836_create_featured_article_contents_table.php
+++ b/api/database/migrations/2021_11_29_134836_create_featured_article_contents_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFeaturedArticleContentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('featured_article_contents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('featured_company_article_id')
+                ->constrained()
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table->string('subTitle');
+            $table->string('image1');
+            $table->string('image1Caption');
+            $table->string('image2');
+            $table->string('image2Caption');
+            $table->string('body');
+            $table->timestamps();
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('featured_article_contents');
+    }
+}

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Favorite;
+use App\Models\FeaturedCompanyArticle;
 use App\Models\FrikuJoboffer;
 use App\Models\HiringSystem;
 use Database\Seeders\UsersTableSeeder;
@@ -37,7 +38,9 @@ class DatabaseSeeder extends Seeder
             HiringSystemsSeeder::class,
             JobTypesSeeder::class,
             StaffsSeeder::class,
-            FrikuCompaniesSeeder::class
+            FrikuCompaniesSeeder::class,
+            FeaturedCompanyArticlesSeeder::class,
+            FeaturedArticleContentsSeeder::class,
         ]);
     }
 }

--- a/api/database/seeders/FeaturedArticleContentsSeeder.php
+++ b/api/database/seeders/FeaturedArticleContentsSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class FeaturedArticleContentsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('featured_article_contents')->insert([
+            'id' => 1,
+            'featured_company_article_id' => 1,
+            'subTitle' => 'サブタイトル',
+            'image1' => 'https://placehold.jp/400x300.png',
+            'image1Caption' => 'image1のキャプション',
+            'image2' => 'https://placehold.jp/400x300.png',
+            'image2Caption' => 'image2のキャプション',
+            'body' => '本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |本文やでー |'
+        ]);
+    }
+}

--- a/api/database/seeders/FeaturedCompanyArticlesSeeder.php
+++ b/api/database/seeders/FeaturedCompanyArticlesSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class FeaturedCompanyArticlesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('featured_company_articles')->insert([
+            'id' => 1,
+            'friku_company_id' => 2,
+            'is_released' => true,
+            'title' => 'タイトルテストタイトルテスト',
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+            'thumbnail_url' => 'https://placehold.jp/150x150.png',
+            'thumbnail_height' => 150,
+            'thumbnail_width' => 150,
+        ]);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -48,7 +48,8 @@ Route::prefix('user')->group(function () {
 
     });
     Route::prefix('/friku')->group(function () {
-        Route::get('/{frikuCompany}/joboffers',[FrikuJobsController::class, 'pickUpCompanyJoboffers'])->name('friku.company.joboffers');
+        Route::get('/{frikuCompany}/joboffers/pickup',[FrikuJobsController::class, 'pickUpCompanyJoboffers'])->name('friku.company.pickupJoboffers');
+        Route::get('/{frikuCompany}/joboffers/feature',[FrikuJobsController::class, 'featureCompanyJoboffers'])->name('friku.company.featureJoboffers');
 
     });
 

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\User\ResetPasswordController;
 use App\Http\Controllers\Api\Staff\SendOfferController;
 use App\Http\Controllers\Api\Staff\UserSearchController;
 use App\Http\Controllers\Api\User\Friku\FrikuJobsController;
+use App\Http\Controllers\Api\User\JobSearchesController;
 use App\Models\FrikuJoboffer;
 
 /*
@@ -43,7 +44,7 @@ Route::prefix('user')->group(function () {
     //Route::prefix('joboffer')内のグループにはjobofferがURIに付きます。
     Route::prefix('/joboffer')->group(function () {
         Route::get('/conditions', [JobsController::class, 'getConditions'])->name('joboffer.conditions');
-        Route::get('/search', [JobsController::class, 'searchJobOffers'])->name('joboffer.search');
+        Route::get('/search', [JobSearchesController::class, 'searchJobOffers'])->name('joboffer.search');
         Route::get('/{corporationJoboffer}', [JobsController::class, 'showJoboffer'])->name('pickup.show');
 
     });


### PR DESCRIPTION
## 作業
- 注目企業の記事、`featured_company_articles`テーブル、注目企業記事のcontentを担当する `featured_article_contents` テーブルを作成
- seedファイルを作成
- JobSearch用のコントローラーの配置場所を変更。
## 動作確認
- テーブルを新規追加しているのと、seedファイルを作成しています。backコンテナに入り`php artisan migrate --seed`実行。無事にseedまで済んだら、 php artisan tinkerを実行し、中で、 `App\Models\FrikuCompany::with('featuredCompanyArticle.featuredArticleContent')->find(2)`コマンドを打って、データを試してみて、問題なければ動作確認終了です。
