### PR TITLE
求人詳細~応募ページTS化

### DIFF
--- a/api/app/Http/Controllers/Api/User/OwnedMaker/JobsController.php
+++ b/api/app/Http/Controllers/Api/User/OwnedMaker/JobsController.php
@@ -55,7 +55,11 @@ class JobsController extends Controller
         //ユーザーの面接申込日データを作成
 
         $applicantschedule->create($scheduleArray);
-        return response()->json(['message' => 'success'], 201);
+        $schedules = CorporationApplicantschedule::with('corporationJoboffer')->where('applicant_id', $user->id)->get();
+        $joboffer = $schedules->map(function ($schedule) {
+            return $schedule->corporationJoboffer;
+        });
+        return response()->json($joboffer, 201, ['message' => 'success']);
 
 
 

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -43,7 +43,7 @@ Route::prefix('user')->group(function () {
     Route::post('/password/reset', [ResetPasswordController::class, 'resetPassword'])->name('password.reset');
     //Route::prefix('joboffer')内のグループにはjobofferがURIに付きます。
     Route::prefix('/joboffer')->group(function () {
-        Route::get('/conditions', [JobsController::class, 'getConditions'])->name('joboffer.conditions');
+        Route::get('/conditions', [JobSearchesController::class, 'getConditions'])->name('joboffer.conditions');
         Route::get('/search', [JobSearchesController::class, 'searchJobOffers'])->name('joboffer.search');
         Route::get('/{corporationJoboffer}', [JobsController::class, 'showJoboffer'])->name('pickup.show');
 

--- a/web/sugnee/contexts/Auth/index.tsx
+++ b/web/sugnee/contexts/Auth/index.tsx
@@ -159,8 +159,8 @@ const AuthProvider = (props: AppProviderProps) => {
       .post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/user/logout`)
       .then((res) => {
         if (res.status === 200) {
-          alert("ログアウトしました");
           setUser(null);
+          Router.push("/");
         } else {
           console.log(res.data);
           console.log("[logout]ログアウト失敗");

--- a/web/sugnee/pages/apply/[id].tsx
+++ b/web/sugnee/pages/apply/[id].tsx
@@ -6,14 +6,20 @@ import axios from "axios";
 // Contexts
 import { AuthContext } from "../../contexts/Auth";
 
-export default function apply({ job }) {
+// Type
+import { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import { JobOffer } from "../../interfaces/job";
+import { User } from "../../interfaces/user";
+
+const apply: NextPage<{ job: JobOffer }> = ({ job }) => {
   const router = useRouter();
   const { user } = useContext(AuthContext);
-  const userFavorites = user?.favorites.map(
-    (favoriteJob) => favoriteJob.corporation_joboffer_id
-  );
 
-  const applyJobOffer = async (e, user, job) => {
+  const applyJobOffer: (
+    e: React.MouseEvent,
+    user: User,
+    job: JobOffer
+  ) => Promise<void> = async (e, user, job) => {
     e.preventDefault();
     if (!user) alert("応募はログインが必要です");
 
@@ -54,7 +60,7 @@ export default function apply({ job }) {
         <div className="hero h-96 bg-gradient-to-b from-primary to-secondary"></div>
       </section>
       <section id="body">
-        <div className="container mx-auto">
+        <div className="container mx-auto mt-10 px-8 md:px-28">
           <p className="bg-primary text-white px-2 py-3 w-full mt-10">応募先</p>
           <div className="border mt-8 p-8">
             <table className="table-fixed w-full mt-8 break-all">
@@ -149,9 +155,11 @@ export default function apply({ job }) {
       </section>
     </>
   );
-}
+};
 
-export async function getStaticPaths() {
+export default apply;
+
+export const getStaticPaths: GetStaticPaths = async () => {
   const allPickupJobs = await axios
     .get("http://nginx:80/api/user/pickup")
     .then((res) => res.data)
@@ -161,9 +169,9 @@ export async function getStaticPaths() {
     paths: allPickupJobs?.map(({ id }) => `/apply/${id}`) ?? [],
     fallback: true,
   };
-}
+};
 
-export async function getStaticProps({ params }) {
+export const getStaticProps: GetStaticProps = async ({ params }) => {
   const job = await axios
     .get(`http://nginx:80/api/user/joboffer/${params.id}`)
     .then((res) => res.data)
@@ -172,4 +180,4 @@ export async function getStaticProps({ params }) {
   return {
     props: { job: job ? job : null },
   };
-}
+};

--- a/web/sugnee/pages/apply/success/index.tsx
+++ b/web/sugnee/pages/apply/success/index.tsx
@@ -5,7 +5,10 @@ import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
 
-export default function applySuccess() {
+// Type
+import { NextPage } from "next";
+
+const applySuccess: NextPage = () => {
   const router = useRouter();
 
   return (
@@ -39,4 +42,6 @@ export default function applySuccess() {
       </section>
     </>
   );
-}
+};
+
+export default applySuccess;

--- a/web/sugnee/pages/job/[id]/index.tsx
+++ b/web/sugnee/pages/job/[id]/index.tsx
@@ -22,9 +22,18 @@ import { JobOffer } from "../../../interfaces/job";
 const jobOffer: NextPage<{ job: JobOffer }> = ({ job }) => {
   const router = useRouter();
   const { user, addOmBookmark, deleteOmBookmark } = useContext(AuthContext);
-  const userFavorites = user?.favorites.friku.map(
+  const userFavorites: number[] = user?.favorites.friku.map(
     (favoriteJob) => favoriteJob.corporation_joboffer_id
   );
+
+  const applyJobOffer = (): void => {
+    // 人材紹介だった場合は導線分けるかも、仕様確定後修正します
+    if (user) {
+      router.push(`/apply/${job.id}`);
+      return;
+    }
+    alert("応募はログインが必要です");
+  };
 
   if (!job) return null;
   return (
@@ -88,10 +97,7 @@ const jobOffer: NextPage<{ job: JobOffer }> = ({ job }) => {
                   お気に入りに追加
                 </button>
               )}
-              <button
-                className="btn btn-primary w-3/4"
-                onClick={() => router.push(`/apply/${job.id}`)}
-              >
+              <button className="btn btn-primary w-3/4" onClick={applyJobOffer}>
                 応募する
               </button>
             </div>

--- a/web/sugnee/pages/job/[id]/index.tsx
+++ b/web/sugnee/pages/job/[id]/index.tsx
@@ -22,7 +22,7 @@ import { JobOffer } from "../../../interfaces/job";
 const jobOffer: NextPage<{ job: JobOffer }> = ({ job }) => {
   const router = useRouter();
   const { user, addOmBookmark, deleteOmBookmark } = useContext(AuthContext);
-  const userFavorites = user?.favorites.map(
+  const userFavorites = user?.favorites.friku.map(
     (favoriteJob) => favoriteJob.corporation_joboffer_id
   );
 

--- a/web/sugnee/pages/job/[id]/index.tsx
+++ b/web/sugnee/pages/job/[id]/index.tsx
@@ -15,7 +15,11 @@ import {
   faClock,
 } from "@fortawesome/free-solid-svg-icons";
 
-export default function job({ job }) {
+// Types
+import { GetStaticProps, GetStaticPaths, NextPage } from "next";
+import { JobOffer } from "../../../interfaces/job";
+
+const jobOffer: NextPage<{ job: JobOffer }> = ({ job }) => {
   const router = useRouter();
   const { user, addOmBookmark, deleteOmBookmark } = useContext(AuthContext);
   const userFavorites = user?.favorites.map(
@@ -52,7 +56,8 @@ export default function job({ job }) {
                 <li>
                   <FontAwesomeIcon icon={faYenSign} className="text-gray-500" />
                   <span className="text-gray-500 ml-3">
-                    {job.salary_min}円〜{job.salary_max}円
+                    {parseInt(job.salary_min).toLocaleString()}〜
+                    {parseInt(job.salary_max).toLocaleString()}円
                   </span>
                 </li>
               </ul>
@@ -71,14 +76,14 @@ export default function job({ job }) {
               {user && userFavorites && isFavorite(userFavorites, job.id) ? (
                 <button
                   className="btn btn-outline btn-primary w-3/4 mb-4"
-                  onClick={(e) => deleteOmBookmark(e, user, job.id)}
+                  onClick={(e) => deleteOmBookmark({ e, user, jobId: job.id })}
                 >
                   お気に入りから削除
                 </button>
               ) : (
                 <button
                   className="btn btn-outline btn-primary w-3/4 mb-4"
-                  onClick={(e) => addOmBookmark(e, user, job.id)}
+                  onClick={(e) => addOmBookmark({ e, user, jobId: job.id })}
                 >
                   お気に入りに追加
                 </button>
@@ -114,7 +119,8 @@ export default function job({ job }) {
                   <th className="w-1/4 text-left pl-4">給与</th>
                   <td className="w-3/4 p-8">
                     {job.salary_pattern}
-                    {job.salary_min}円〜{job.salary_max}円
+                    {parseInt(job.salary_min).toLocaleString()}〜
+                    {parseInt(job.salary_max).toLocaleString()}円
                   </td>
                 </tr>
                 <tr className="border-b border-gray-300">
@@ -158,14 +164,14 @@ export default function job({ job }) {
           {user && userFavorites && isFavorite(userFavorites, job.id) ? (
             <button
               className="btn btn-outline btn-primary w-2/5 mr-3"
-              onClick={(e) => deleteOmBookmark(e, user, job.id)}
+              onClick={(e) => deleteOmBookmark({ e, user, jobId: job.id })}
             >
               お気に入りから削除
             </button>
           ) : (
             <button
               className="btn btn-outline btn-primary w-2/5 mr-3"
-              onClick={(e) => addOmBookmark(e, user, job.id)}
+              onClick={(e) => addOmBookmark({ e, user, jobId: job.id })}
             >
               お気に入りに追加
             </button>
@@ -180,9 +186,11 @@ export default function job({ job }) {
       </section>
     </>
   );
-}
+};
 
-export async function getStaticPaths() {
+export default jobOffer;
+
+export const getStaticPaths: GetStaticPaths = async () => {
   const allPickupJobs = await axios
     .get("http://nginx:80/api/user/pickup")
     .then((res) => res.data)
@@ -192,9 +200,9 @@ export async function getStaticPaths() {
     paths: allPickupJobs?.map(({ id }) => `/jobOffer/job/${id}`) ?? [],
     fallback: true,
   };
-}
+};
 
-export async function getStaticProps({ params }) {
+export const getStaticProps: GetStaticProps = async ({ params }) => {
   const job = await axios
     .get(`http://nginx:80/api/user/joboffer/${params.id}`)
     .then((res) => res.data)
@@ -203,4 +211,4 @@ export async function getStaticProps({ params }) {
   return {
     props: { job: job ? job : null },
   };
-}
+};

--- a/web/sugnee/pages/job/index.tsx
+++ b/web/sugnee/pages/job/index.tsx
@@ -11,17 +11,24 @@ import OmJobCard from "../../components/Card/OmJobCard";
 
 // Types
 import { NextPage } from "next";
+import { JobOffer } from "../../interfaces/job";
 
 const job: NextPage = () => {
-  const [jobOffers, setJobOffers] = useState();
+  const [jobOffers, setJobOffers] = useState<[JobOffer]>();
   const { workTypes, searchCondition, searchJobOffers } = useContext(
     SearchConditionContext
   );
   const { user } = useContext(AuthContext);
-  const userFavorites = user?.favorites.map((favoriteJob) => favoriteJob.id);
+  // cardデザインが決まったら修正します
+  const userFrikuFavorites: number[] = user?.favorites.friku.map(
+    (favoriteJob) => favoriteJob.id
+  );
+  const userOmFavorites: number[] = user?.favorites.friku.map(
+    (favoriteJob) => favoriteJob.id
+  );
 
   useEffect(() => {
-    const getJobData = async () => {
+    const getJobData = async (): Promise<void> => {
       const jobData = await searchJobOffers(searchCondition);
       setJobOffers(jobData);
     };
@@ -33,7 +40,7 @@ const job: NextPage = () => {
 
   if (!jobOffers) {
     return null;
-  } else if (jobOffers.length === 0) {
+  } else if (!jobOffers.length) {
     return <p>検索条件に一致する求人はありません</p>;
   }
 
@@ -69,13 +76,14 @@ const job: NextPage = () => {
         </div>
         <div className="w-full lg:w-3/4 p-5">
           <p>検索結果一覧</p>
+          {/* デザインが決まったら修正します */}
           {jobOffers.length &&
             jobOffers.map((job) => (
               <div className="w-full mb-3" key={job.id}>
                 <OmJobCard
                   job={job}
                   user={user}
-                  userFavorites={userFavorites}
+                  userFavorites={userOmFavorites}
                 />
               </div>
             ))}

--- a/web/sugnee/pages/job/index.tsx
+++ b/web/sugnee/pages/job/index.tsx
@@ -9,19 +9,23 @@ import { SearchConditionContext } from "../../contexts/SearchCondition";
 import JobSearchSidebar from "../../components/JobSearchSidebar";
 import OmJobCard from "../../components/Card/OmJobCard";
 
-export default function Job() {
+// Types
+import { NextPage } from "next";
+
+const job: NextPage = () => {
   const [jobOffers, setJobOffers] = useState();
   const { workTypes, searchCondition, searchJobOffers } = useContext(
     SearchConditionContext
   );
   const { user } = useContext(AuthContext);
-  const userFavorites = user?.favorites.map(
-    (favoriteJob) => favoriteJob.corporation_joboffer_id
-  );
+  const userFavorites = user?.favorites.map((favoriteJob) => favoriteJob.id);
 
-  useEffect(async () => {
-    const jobData = await searchJobOffers(searchCondition);
-    setJobOffers(jobData);
+  useEffect(() => {
+    const getJobData = async () => {
+      const jobData = await searchJobOffers(searchCondition);
+      setJobOffers(jobData);
+    };
+    getJobData();
   }, []);
 
   console.log("検索条件", searchCondition);
@@ -79,4 +83,6 @@ export default function Job() {
       </div>
     </div>
   );
-}
+};
+
+export default job;

--- a/web/sugnee/pages/pickup/[id]/index.tsx
+++ b/web/sugnee/pages/pickup/[id]/index.tsx
@@ -28,10 +28,7 @@ import {
 import { pickupArticle, JobOffer } from "../../../interfaces/job";
 interface pickUpArticleProps {
   article: pickupArticle;
-  jobData: {
-    // returnされるデータが変更されたら定義します
-    frikuJoboffers?: [JobOffer];
-  };
+  jobData: [JobOffer];
 }
 
 export default function pickUpArticle({
@@ -39,8 +36,7 @@ export default function pickUpArticle({
   jobData,
 }: pickUpArticleProps) {
   const { user } = useContext(AuthContext);
-  // getUserでreturnされるfavoriteJobが変更されたら定義してエラー解消します
-  const userFavorites = user?.favorites.map(
+  const userFavorites = user?.favorites.friku.map(
     (favoriteJob) => favoriteJob.corporation_joboffer_id
   );
 
@@ -187,7 +183,7 @@ export default function pickUpArticle({
       <section id="jobOffers" style={{ backgroundColor: "#E6F2F4" }}>
         <div className="container mx-auto px-8 py-28 md:px-28">
           <h2 className="text-2xl font-bold mb-16">求人情報</h2>
-          {jobData.frikuJoboffers.map((job) => (
+          {jobData.map((job) => (
             <div key={job.id} className="mb-3">
               <PickupJobCard
                 job={job}
@@ -223,7 +219,7 @@ export async function getStaticProps({ params }) {
 
   // 今は1しか存在しないので1で対応、のちにarticle.companyIdを渡すよう変更＆エラーハンドリングします
   const jobData = await axios
-    .get(`http://nginx:80/api/user/friku/1/joboffers`)
+    .get(`http://nginx:80/api/user/friku/1/joboffers/pickup`)
     .then((res) => res.data)
     .catch((err) => console.log(err));
 


### PR DESCRIPTION
## 対応
- https://github.com/local-venture-group/Sugnee/issues/106#issue-1065726876
- `/job`ページと`/apply`ページをTS化
- `/job/[id]`ページで応募するボタンをクリックした際、未ログインであればアラート表示

## 動作確認
`http://localhost/job/3`にアクセスし、未ログインのまま応募するボタンをクリックした際にアラート表示されることを確認してください。
<img width="1775" alt="スクリーンショット 2021-11-30 11 01 05" src="https://user-images.githubusercontent.com/65808877/143972965-c665d9fe-8366-4242-9885-482dfdc79542.png">

ログイン後、応募するボタンをクリックしたら応募確認ページ=>応募完了ページに飛ぶことを確認してください。
<img width="1759" alt="スクリーンショット 2021-11-30 11 01 49" src="https://user-images.githubusercontent.com/65808877/143973024-cfa2354c-c114-4ebd-9ad2-f618ce1a7fd6.png">

## お願い🙏
OM求人へ応募した際、returnするデータに現在のOM応募済み求人を含んでもらえたらありがたいです！（お気に入り追加と同じ）
現在はmessageのみres.dataに入っています。
<img width="232" alt="スクリーンショット 2021-11-30 11 05 27" src="https://user-images.githubusercontent.com/65808877/143973162-107c4d92-9279-4b87-8e6a-4e241f484bc4.png">


