### PR TITLE
UserControllerのgetAuthUser, login , register後の返却ユーザー情報の修正

### DIFF
--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -32,18 +32,21 @@ class UserController extends Controller
 
             $request->session()->regenerate();
             $user = User::findOrFail(Auth::guard('users')->id());
-            $withUser = $user->with('frikuApplicant.frikuApplicantSchedules')->first();
+            // $withUser = $user->with('frikuApplicant.frikuApplicantSchedules')->first();
 
             $favoritesJobs = $userService->getOmFavorited($user);
-            $favoritesJobs += $userService->getFrikuFavorited($withUser);
+            $favoritesJobs += $userService->getFrikuFavorited($user);
             $applied = [];
             $applied = $userService->getOmApplied($user);
-            $applied += $userService->getFrikuApplied($withUser);
+            $applied += $userService->getFrikuApplied($user);
 
-            $user->favorites = $favoritesJobs;
-            $user->appliedJobs = $applied;
+            // $user->favorites = $favoritesJobs;
+            // $user->appliedJobs = $applied;
+            $editedUser = User::findOrFail(Auth::guard('users')->id());
+            $editedUser->favorites = $favoritesJobs;
+            $editedUser->appliedJobs = $applied;
             return response()->json([
-                'user' =>  $user,
+                'user' =>  $editedUser,
                 'message' => "ログインに成功しました"
             ]);
         }
@@ -110,7 +113,7 @@ class UserController extends Controller
         // $user->favorites = $favoritesJobs;
         //④ Fリク求人の応募済みを取得
         $applied['friku'] = [];
-        if($user->frikuApplicant){
+        if ($user->frikuApplicant) {
             $frikuApplicant = $user->frikuApplicant;
             $applied['friku'] = collect($frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
                 return $schedule->frikuJoboffer;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -92,4 +92,5 @@ class User extends Authenticatable
         return $this->hasOne(FrikuApplicant::class, 'user_id');
     }
 
+
 }

--- a/api/app/Providers/UserServiceProvider.php
+++ b/api/app/Providers/UserServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\UserService;
+use Illuminate\Support\ServiceProvider;
+
+class UserServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind(
+            'UserService',
+            UserService::class
+        );
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/api/app/Services/UserService.php
+++ b/api/app/Services/UserService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\CorporationApplicantschedule;
+use App\Models\CorporationJoboffer;
+use App\Models\Favorite;
+use App\Models\User;
+
+class UserService
+{
+    public function getOmFavorited(User $user)
+    {
+        $omfavorites = Favorite::where('user_id', $user->id)->get();
+
+        $favoritesOmBaseJobs = CorporationJoboffer::whereIn('id', $omfavorites->pluck('corporation_joboffer_id'))->get();
+        return  ['om' => $favoritesOmBaseJobs];
+    }
+    public function getFrikuFavorited(User $withUser)
+    {
+        $favoritesFrikuBaseJobs = $withUser->frikuFavorites;
+        return ['friku' => $favoritesFrikuBaseJobs];
+    }
+    public function getOmApplied(User $user)
+    {
+        $applicantWithApplied = CorporationApplicantschedule::with('corporationJoboffer')
+            ->where('applicant_id', $user->id)
+            ->get();
+            $applied = [];
+            if(!empty($applicantWithApplied)){
+                $applied['om'] = $applicantWithApplied->map(function ($schedule) {
+
+                    return $schedule->corporationJoboffer;
+                });
+            }
+        return $applied;
+    }
+
+    public function getFrikuApplied(User $withUser)
+    {
+        $applied['friku'] = [];
+        if(empty($withUser->frikuApplicant)){
+            return $applied;
+
+            if(empty($withUser->frikuApplicant->frikuApplicantSchedules)){
+                return $applied;
+            }
+        }
+
+        $applied['friku'] = collect($withUser->frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
+            return $schedule->frikuJoboffer;
+        });
+        return $applied;
+
+
+    }
+}

--- a/api/app/Services/UserService.php
+++ b/api/app/Services/UserService.php
@@ -39,17 +39,24 @@ class UserService
     public function getFrikuApplied(User $withUser)
     {
         $applied['friku'] = [];
-        if(empty($withUser->frikuApplicant)){
-            return $applied;
+        // if(empty($withUser->frikuApplicant)){
+        //     return $applied;
 
-            if(empty($withUser->frikuApplicant->frikuApplicantSchedules)){
-                return $applied;
-            }
+        //     if(empty($withUser->frikuApplicant->frikuApplicantSchedules)){
+        //         return $applied;
+        //     }
+        // }
+
+        // $applied['friku'] = collect($withUser->frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
+        //     return $schedule->frikuJoboffer;
+        // });
+        // return $applied;
+        if($withUser->frikuApplicant){
+            $frikuApplicant = $withUser->frikuApplicant;
+            $applied['friku'] = collect($frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
+                return $schedule->frikuJoboffer;
+            });
         }
-
-        $applied['friku'] = collect($withUser->frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
-            return $schedule->frikuJoboffer;
-        });
         return $applied;
 
 

--- a/api/config/app.php
+++ b/api/config/app.php
@@ -242,6 +242,7 @@ return [
         'View' => Illuminate\Support\Facades\View::class,
         'JobService' => App\Facades\JobService::class,
         'ApplyService' => \App\Facades\ApplyService::class,
+        'UserService' => \App\Facades\UserService::class,
     ],
 
 ];


### PR DESCRIPTION
**遅れて申し訳ありません**
## 作業内容
- getAuthUserメソッド内でリレーション先が存在しない場合は空配列を渡すように修正。
- loginメソッド内で、お気に入り求人と応募済求人を取得してくるように修正
- register後に、空のお気に入りと応募済の配列を渡すように追加
- 上記の、ログインユーザーのデータに修正、加工を加える専用のクラス、UserServiceクラスを作成して処理を統一化
## 動作確認
**下記工程全てで、returnにfrikuFavorite frikuAppliedのような名前の(少し違うかもしれませんが)データが含まれていないことを確認して頂きたいです**
1. `http://localhost/login`で、メアド`user1@example.com` パスワード`password`ログインボタンをクリックでログイン。検証ツールのネットワークタブ　プレビューのloginにて、appliedJobsとfavoritesにそれぞれomとfrikuが入っているか。
2. ページリロードをして、同じくネットワークタブ、プレビューのuserにて、appliedJobsとfavoritesにそれぞれomとfrikuが入っているか。
3. メアド `user2@example.com` パスワード`password` でログインをして、上記1 , 2の作業を行い、その際は空のomとfavoritesの配列が入っているか
4.  `http://localhost/signup` から登録を行う(手順省略)　登録後、ネットワークタブのプレビューにて、favoritesの空が含まれているかどうか。

1
<img width="753" alt="スクリーンショット 2021-12-01 12 02 31" src="https://user-images.githubusercontent.com/61079243/144164380-a2e304ac-654f-409f-b4b4-fae4e13ab8f2.png">
2
<img width="750" alt="スクリーンショット 2021-12-01 12 02 10" src="https://user-images.githubusercontent.com/61079243/144166086-06770cd0-7efe-46a1-a195-ea0dab70b950.png">
3.A
<img width="740" alt="スクリーンショット 2021-12-01 12 23 56" src="https://user-images.githubusercontent.com/61079243/144167042-7cf439e1-01ff-4d18-96df-6d748b4cce70.png">
3>B
<img width="733" alt="スクリーンショット 2021-12-01 12 32 18" src="https://user-images.githubusercontent.com/61079243/144167131-f1fafa65-0ebb-4b94-9fee-868b17c485c6.png">


