### PR TITLE
type_of_jobの付与　修正

### DIFF
--- a/api/app/Http/Controllers/Api/User/Friku/FrikuJobsController.php
+++ b/api/app/Http/Controllers/Api/User/Friku/FrikuJobsController.php
@@ -13,24 +13,25 @@ class FrikuJobsController extends Controller
 {
 
     //企業の求人一覧を取得
-    public function pickUpCompanyJoboffers(FrikuCompany $frikuCompany)
+    public function pickUpCompanyJoboffers($frikuCompany)
     {
-        if(!$frikuCompany->is_pickup){
+        $frikuCompany = FrikuCompany::with('frikuJoboffers')->findOrFail($frikuCompany);
+        if (!$frikuCompany->is_pickup) {
             return response()->json(['message' => 'pickUp企業の求人ではありません']);
         }
-        $pickUpCompany = $frikuCompany->with('frikuJoboffers')->first();
-        $pickUpJobs =  $pickUpCompany->frikuJoboffers;
+        $pickUpJobs =  $frikuCompany->frikuJoboffers;
+
         return JobResource::collection($pickUpJobs)->toJson();
         // return collect(new JobResource($pickUpJobs));
     }
-    public function featureCompanyJoboffers(FrikuCompany $frikuCompany)
+    public function featureCompanyJoboffers($frikuCompany)
     {
-
-        if($frikuCompany->is_pickup){
+        $frikuCompany = FrikuCompany::with('frikuJoboffers')->findOrFail($frikuCompany);
+        if ($frikuCompany->is_pickup) {
             return response()->json(['message' => '注目企業の求人ではありません']);
         }
-        $featureCompany = $frikuCompany->with('frikuJoboffers')->first();
-        $featureJobs =  $featureCompany->frikuJoboffers;
+        $featureJobs =  $frikuCompany->frikuJoboffers;
+
         return JobResource::collection($featureJobs)->toJson();
     }
 }

--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -45,6 +45,7 @@ class UserController extends Controller
             $editedUser = User::findOrFail(Auth::guard('users')->id());
             $editedUser->favorites = $favoritesJobs;
             $editedUser->appliedJobs = $applied;
+
             return response()->json([
                 'user' =>  $editedUser,
                 'message' => "ログインに成功しました"

--- a/api/app/Http/Resources/JobResource.php
+++ b/api/app/Http/Resources/JobResource.php
@@ -21,9 +21,9 @@ class JobResource extends JsonResource
         ? JobConditionConsts::HIRING_SYSTEMS[$this->resource->hiring_system]
         : "" ;
 
-        if($this->resource->type_of_job){
-            $this->type_of_job = $this->resource->type_of_job[0];
-        }
+        // if($this->resource->type_of_job){
+        //     $this->type_of_job = $this->resource->type_of_job[0];
+        // }
 
         return [
              'id' => $this->id,
@@ -74,7 +74,7 @@ class JobResource extends JsonResource
             "image2" => $this->resource->image2,
             "image3" => $this->resource->image3,
             "image4" => $this->resource->image4,
-            "type_of_job" => $this->type_of_job,
+            "type_of_job" => $this->resource->type_of_job,
             'created_at' => $this->resource->created_at,
             'updated_at' => $this->resource->updated_at,
         ];

--- a/api/app/Http/Resources/JobResource.php
+++ b/api/app/Http/Resources/JobResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Consts\JobConditionConsts;
+use App\Models\FrikuCompany;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class JobResource extends JsonResource
@@ -19,14 +20,10 @@ class JobResource extends JsonResource
         $this->resource->hiring_system = array_key_exists($this->resource->hiring_system, JobConditionConsts::HIRING_SYSTEMS)
         ? JobConditionConsts::HIRING_SYSTEMS[$this->resource->hiring_system]
         : "" ;
-        // $this->resource->type_of_job = $this->resource->is_crawled
-        //     ? array_keys(JobConditionConsts::TYPE_OF_JOB, 'OMクローリング求人')
-        //     : array_keys(JobConditionConsts::TYPE_OF_JOB, 'OM独自求人');
-        // $this->resource->type_of_job = array_key_exists($this->resource->type_of_job, JobConditionConsts::TYPE_OF_JOB);
+
         if($this->resource->type_of_job){
             $this->type_of_job = $this->resource->type_of_job[0];
         }
-
 
         return [
              'id' => $this->id,

--- a/api/app/Models/FrikuJoboffer.php
+++ b/api/app/Models/FrikuJoboffer.php
@@ -2,16 +2,26 @@
 
 namespace App\Models;
 
+use App\Consts\JobConditionConsts;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\User;
 use App\Models\FrikuCompany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Request;
 
 class FrikuJoboffer extends Model
 {
     use HasFactory;
-
+    protected $connection = 'fukuriku';
+    protected $appends = ['type_of_job'];
+    public function getTypeOfJobAttribute()
+    {
+        $comp = FrikuCompany::findOrFail($this->company_id);
+        return  $comp->is_pickup === true
+            ? array_keys(JobConditionConsts::TYPE_OF_JOB, 'ピックアップ求人')
+            : array_keys(JobConditionConsts::TYPE_OF_JOB, '注目企業求人');
+    }
     public function frikuFavorited(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'friku_favorites');

--- a/api/app/Services/UserService.php
+++ b/api/app/Services/UserService.php
@@ -14,11 +14,17 @@ class UserService
         $omfavorites = Favorite::where('user_id', $user->id)->get();
 
         $favoritesOmBaseJobs = CorporationJoboffer::whereIn('id', $omfavorites->pluck('corporation_joboffer_id'))->get();
+        $favoritesOmBaseJobs->each(function ($job){
+            $job->append('type_of_job');
+        });
         return  ['om' => $favoritesOmBaseJobs];
     }
     public function getFrikuFavorited(User $withUser)
     {
         $favoritesFrikuBaseJobs = $withUser->frikuFavorites;
+        $favoritesFrikuBaseJobs->each(function ($job){
+            $job->append('type_of_job');
+        });
         return ['friku' => $favoritesFrikuBaseJobs];
     }
     public function getOmApplied(User $user)
@@ -26,12 +32,17 @@ class UserService
         $applicantWithApplied = CorporationApplicantschedule::with('corporationJoboffer')
             ->where('applicant_id', $user->id)
             ->get();
-            $applied = [];
+            $applied['om'] = [];
             if(!empty($applicantWithApplied)){
-                $applied['om'] = $applicantWithApplied->map(function ($schedule) {
+
+                $omJoboffer = $applicantWithApplied->map(function ($schedule) {
 
                     return $schedule->corporationJoboffer;
                 });
+                $omJoboffer->each(function ($job){
+                    $job->append('type_of_job');
+                });
+                $applied['om'] = $omJoboffer;
             }
         return $applied;
     }
@@ -39,23 +50,15 @@ class UserService
     public function getFrikuApplied(User $withUser)
     {
         $applied['friku'] = [];
-        // if(empty($withUser->frikuApplicant)){
-        //     return $applied;
-
-        //     if(empty($withUser->frikuApplicant->frikuApplicantSchedules)){
-        //         return $applied;
-        //     }
-        // }
-
-        // $applied['friku'] = collect($withUser->frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
-        //     return $schedule->frikuJoboffer;
-        // });
-        // return $applied;
         if($withUser->frikuApplicant){
             $frikuApplicant = $withUser->frikuApplicant;
-            $applied['friku'] = collect($frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
+            $frikuJoboffer = collect($frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
                 return $schedule->frikuJoboffer;
             });
+            $frikuJoboffer->each(function ($job){
+                $job->append('type_of_job');
+            });
+            $applied['friku'] = $frikuJoboffer;
         }
         return $applied;
 

--- a/api/database/seeders/FrikuCompaniesSeeder.php
+++ b/api/database/seeders/FrikuCompaniesSeeder.php
@@ -59,6 +59,20 @@ class FrikuCompaniesSeeder extends Seeder
             'user_id' => 3,
             'plan' => 1
         ],
+        [
+            'username_kana' => '不動峰株式会社',
+            'first_name_kana' => 'キッペイ',
+            'last_name_kana' => 'タチバナ',
+            'company_phone' => '0120-344-221',
+            'site_url'=> 'https://www.google.com/',
+            'logo' => 'https://placehold.jp/150x150.png',
+            'address' => '福岡市早良区',
+            'is_pickup' => true,
+            'is_registered' => true,
+            'temp_id' => Str::uuid(),
+            'user_id' => 3,
+            'plan' => 1
+        ],
 
         ]);
     }

--- a/api/database/seeders/FrikuJoboffersSeeder.php
+++ b/api/database/seeders/FrikuJoboffersSeeder.php
@@ -21,5 +21,8 @@ class FrikuJoboffersSeeder extends Seeder
         FrikuJoboffer::factory(3)->create([
             'company_id' => 3,
         ]);
+        FrikuJoboffer::factory(4)->create([
+            'company_id' => 4,
+        ]);
     }
 }


### PR DESCRIPTION
## 作業内容
- https://github.com/local-venture-group/Sugnee/issues/119
- ピックアップ求人と注目求人のreturnデータの`type_of_job`をnullからちゃんと値が入るように修正
- user情報をreturnするapiのお気に入り＆応募済求人に`type_of_job` を付与
- ピックアップ求人API 注目企業求人APIが想定通りに機能してないことに気づいたので修正
## 動作確認
ピックアップ求人api
`http://localhost/api/user/friku/1/joboffers/pickup`
注目企業求人api
`http://localhost/api/user/friku/3/joboffers/feature`
この2つを叩いて、各種求人にちゃんとtype_of_jobが入っているかどうか
`http://localhost/login`　からログインをした時のlogin情報
ログイン後、ページリロード後のuser情報
これらにtype_of_jobが入っているかどうか

これらに全てtype_of_jobが入っていたら動作確認完了です。