### PR TITLE
ユーザー情報にお気に入り＆応募済み求人追加 

### DIFF
--- a/web/sugnee/components/Footer/index.tsx
+++ b/web/sugnee/components/Footer/index.tsx
@@ -14,7 +14,7 @@ const Footer: React.FC = () => {
       <div>
         <Link href="/">
           <a className="text-2xl font-bold text-gray-800 dark:text-white lg:text-3xl hover:text-gray-700 dark:hover:text-gray-300">
-            FUK REC
+            Sugnee
           </a>
         </Link>
         <div className="grid grid-flow-col gap-4">

--- a/web/sugnee/components/Header/index.tsx
+++ b/web/sugnee/components/Header/index.tsx
@@ -28,7 +28,7 @@ export default function Header() {
           <div className="text-xl font-semibold text-gray-700">
             <Link href="/">
               <a className="text-2xl font-bold text-gray-800 dark:text-white lg:text-3xl hover:text-gray-700 dark:hover:text-gray-300">
-                FUK REC
+                Sugnee
               </a>
             </Link>
           </div>

--- a/web/sugnee/components/Layout/index.tsx
+++ b/web/sugnee/components/Layout/index.tsx
@@ -1,9 +1,11 @@
 import Header from "../Header";
 import Footer from "../Footer";
+import Seo from "../Seo";
 
 const Layout: React.FC = ({ children }) => {
   return (
     <>
+      <Seo />
       <div className="bg-white">
         <Header />
         <div className="container-lg mx-auto">{children}</div>

--- a/web/sugnee/components/MypageJobList/index.tsx
+++ b/web/sugnee/components/MypageJobList/index.tsx
@@ -1,0 +1,34 @@
+// Components
+import OmJobCard from "../Card/OmJobCard";
+import PickupJobCard from "../Card/PickupJobCard";
+
+// Types
+import { User } from "../../interfaces/user";
+
+const MypageJobList: React.FC<{ user: User; type: string }> = ({
+  user,
+  type,
+}) => {
+  const jobList =
+    type === "favorite"
+      ? user.favorites.om.concat(user.favorites.friku)
+      : user.appliedJobs.om.concat(user.appliedJobs.friku);
+  const userOmFavorites = user?.favorites.om.map(
+    (favoriteJob) => favoriteJob.id
+  );
+  const userFrikuFavorites = user?.favorites.friku.map(
+    (favoriteJob) => favoriteJob.id
+  );
+
+  console.log(jobList);
+
+  return (
+    <div>
+      {jobList.map((job) => (
+        <OmJobCard job={job} user={user} userFavorites={userOmFavorites} />
+      ))}
+    </div>
+  );
+};
+
+export default MypageJobList;

--- a/web/sugnee/components/MypageJobList/index.tsx
+++ b/web/sugnee/components/MypageJobList/index.tsx
@@ -24,9 +24,30 @@ const MypageJobList: React.FC<{ user: User; type: string }> = ({
 
   return (
     <div>
-      {jobList.map((job) => (
-        <OmJobCard job={job} user={user} userFavorites={userOmFavorites} />
-      ))}
+      <h1>{type}</h1>
+      {jobList.length ? (
+        jobList.map((job) => {
+          job.type_of_job[0] === 2 || 3 ? (
+            <div className="mb-3">
+              <OmJobCard
+                job={job}
+                user={user}
+                userFavorites={userOmFavorites}
+              />
+            </div>
+          ) : (
+            <div className="mb-3">
+              <PickupJobCard
+                job={job}
+                user={user}
+                userFavorites={userFrikuFavorites}
+              />
+            </div>
+          );
+        })
+      ) : (
+        <p>{type === "favorite" ? "お気に入り" : "応募済み"}求人はありません</p>
+      )}
     </div>
   );
 };

--- a/web/sugnee/components/MypageJobList/index.tsx
+++ b/web/sugnee/components/MypageJobList/index.tsx
@@ -11,8 +11,8 @@ const MypageJobList: React.FC<{ user: User; type: string }> = ({
 }) => {
   const jobList =
     type === "favorite"
-      ? user.favorites.om.concat(user.favorites.friku)
-      : user.appliedJobs.om.concat(user.appliedJobs.friku);
+      ? user.favorites.friku.concat(user.favorites.om)
+      : user.appliedJobs.friku.concat(user.appliedJobs.om);
   const userOmFavorites = user?.favorites.om.map(
     (favoriteJob) => favoriteJob.id
   );
@@ -20,38 +20,30 @@ const MypageJobList: React.FC<{ user: User; type: string }> = ({
     (favoriteJob) => favoriteJob.id
   );
 
-  console.log(jobList);
-
   return (
     <div>
-      <h1>{type}</h1>
       {jobList.length === 0 ? (
         <p>{type === "favorite" ? "お気に入り" : "応募済み"}求人はありません</p>
       ) : (
-        jobList.map((job) => (
-          <div className="mb-3">
-            <OmJobCard job={job} user={user} userFavorites={userOmFavorites} />
-          </div>
-        ))
-        // jobList.map((job) => {
-        // job.type_of_job[0] === 2 || 3 ? (
-        //   <div className="mb-3">
-        //     <OmJobCard
-        //       job={job}
-        //       user={user}
-        //       userFavorites={userOmFavorites}
-        //     />
-        //   </div>
-        // ) : (
-        //   <div className="mb-3">
-        //     <PickupJobCard
-        //       job={job}
-        //       user={user}
-        //       userFavorites={userFrikuFavorites}
-        //     />
-        //   </div>
-        // );
-        // })
+        jobList.map((job) => {
+          return job.type_of_job[0] === 2 || job.type_of_job[0] === 3 ? (
+            <div className="mb-3" key={`${job.type_of_job}-${job.id}`}>
+              <OmJobCard
+                job={job}
+                user={user}
+                userFavorites={userOmFavorites}
+              />
+            </div>
+          ) : (
+            <div className="mb-3" key={`${job.type_of_job}-${job.id}`}>
+              <PickupJobCard
+                job={job}
+                user={user}
+                userFavorites={userFrikuFavorites}
+              />
+            </div>
+          );
+        })
       )}
     </div>
   );

--- a/web/sugnee/components/MypageJobList/index.tsx
+++ b/web/sugnee/components/MypageJobList/index.tsx
@@ -25,28 +25,33 @@ const MypageJobList: React.FC<{ user: User; type: string }> = ({
   return (
     <div>
       <h1>{type}</h1>
-      {jobList.length ? (
-        jobList.map((job) => {
-          job.type_of_job[0] === 2 || 3 ? (
-            <div className="mb-3">
-              <OmJobCard
-                job={job}
-                user={user}
-                userFavorites={userOmFavorites}
-              />
-            </div>
-          ) : (
-            <div className="mb-3">
-              <PickupJobCard
-                job={job}
-                user={user}
-                userFavorites={userFrikuFavorites}
-              />
-            </div>
-          );
-        })
-      ) : (
+      {jobList.length === 0 ? (
         <p>{type === "favorite" ? "お気に入り" : "応募済み"}求人はありません</p>
+      ) : (
+        jobList.map((job) => (
+          <div className="mb-3">
+            <OmJobCard job={job} user={user} userFavorites={userOmFavorites} />
+          </div>
+        ))
+        // jobList.map((job) => {
+        // job.type_of_job[0] === 2 || 3 ? (
+        //   <div className="mb-3">
+        //     <OmJobCard
+        //       job={job}
+        //       user={user}
+        //       userFavorites={userOmFavorites}
+        //     />
+        //   </div>
+        // ) : (
+        //   <div className="mb-3">
+        //     <PickupJobCard
+        //       job={job}
+        //       user={user}
+        //       userFavorites={userFrikuFavorites}
+        //     />
+        //   </div>
+        // );
+        // })
       )}
     </div>
   );

--- a/web/sugnee/components/MypageJobList/index.tsx
+++ b/web/sugnee/components/MypageJobList/index.tsx
@@ -11,8 +11,8 @@ const MypageJobList: React.FC<{ user: User; type: string }> = ({
 }) => {
   const jobList =
     type === "favorite"
-      ? user.favorites.friku.concat(user.favorites.om)
-      : user.appliedJobs.friku.concat(user.appliedJobs.om);
+      ? user?.favorites.friku.concat(user.favorites.om)
+      : user?.appliedJobs.friku.concat(user.appliedJobs.om);
   const userOmFavorites = user?.favorites.om.map(
     (favoriteJob) => favoriteJob.id
   );

--- a/web/sugnee/components/Profile/index.tsx
+++ b/web/sugnee/components/Profile/index.tsx
@@ -17,16 +17,16 @@ const Profile = ({ user, updateProfile }) => {
   } = useForm();
 
   //画像アップロード
-  const [image, setImage] = useState<string | null>(null);
+  const [image, setImage] = useState<string | null>(user?.img_path);
   const [src, setSrc] = useState<string | null>(null);
 
   const [crop, setCrop] = useState<Crop>({
     unit: "%",
-    x: 25,
+    x: 15,
     y: 10,
-    width: 80,
-    height: 80,
-    aspect: 4 / 4,
+    aspect: 1 / 1,
+    width: 50,
+    height: 50,
   });
   const [imageRef, setImageRef] = useState<HTMLImageElement | null>(null);
 

--- a/web/sugnee/components/Profile/index.tsx
+++ b/web/sugnee/components/Profile/index.tsx
@@ -28,7 +28,6 @@ const Profile = ({ user, updateProfile }) => {
     width: 200,
     height: 200,
   });
-  const [completedCrop, setCompletedCrop] = useState<Crop | null>(null);
   const imageRef = useRef<HTMLImageElement | null>(null);
 
   // 画像読み込み
@@ -55,8 +54,6 @@ const Profile = ({ user, updateProfile }) => {
       const scaleX = image.naturalWidth / image.width;
       const scaleY = image.naturalHeight / image.height;
       const ctx = canvas.getContext("2d");
-
-      console.log("check", image.naturalWidth, image.width);
 
       canvas.width = crop.width * pixelRatio * scaleX;
       canvas.height = crop.height * pixelRatio * scaleY;
@@ -93,9 +90,9 @@ const Profile = ({ user, updateProfile }) => {
 
   return (
     <>
-      <div className="w-full md:w-3/4 bg-white mb-6">
-        <div className="w-full md:flex px-10 py-6 md:mb-0">
-          <div className="avatar placeholder text-center">
+      <div className="w-full md:w-3/4 bg-white px-10 py-6 rounded">
+        <div className="text-center">
+          <div className="avatar placeholder my-6">
             {profileImage ? (
               <label
                 htmlFor="cropModal"
@@ -108,7 +105,10 @@ const Profile = ({ user, updateProfile }) => {
                 htmlFor="cropModal"
                 className="bg-neutral-content text-neutral-content rounded-full w-32 h-32 hover:bg-primary hover:shadow"
               >
-                <img src={user.img_path} style={{ borderRadius: "100%" }} />
+                <img
+                  src={`http://${user.img_path}`}
+                  style={{ borderRadius: "100%" }}
+                />
               </label>
             ) : (
               <label
@@ -133,21 +133,13 @@ const Profile = ({ user, updateProfile }) => {
               addProfileImage={addProfileImage}
             />
           </div>
-
-          <div className="pl-6">
-            <p className="text-3xl mb-3　">{user.name}</p>
-            <p className="text-lg text-gray-500">{user.birth}</p>
-            <p className="text-lg text-gray-500">
-              {user.gender === 1 ? "男性" : "女性"}
-            </p>
-          </div>
         </div>
-      </div>
-      <div className="w-full md:w-3/4 bg-white px-10 py-6">
+
         <form
           onSubmit={handleSubmit((data) =>
             updateProfile({ data, image: profileImage })
           )}
+          className="w-full md:w-8/12 md:mx-auto"
         >
           <div className="w-full md:mb-0">
             <label

--- a/web/sugnee/components/Seo/index.tsx
+++ b/web/sugnee/components/Seo/index.tsx
@@ -18,8 +18,8 @@ const Seo: React.FC<SeoProps> = ({
   pageImgWidth,
   pageImgHeight,
 }) => {
-  const defaultTitle = "Fリク";
-  const defaultDescription = "九州であなたに合ったお仕事を探すなら、Fリク！";
+  const defaultTitle = "Sugnee";
+  const defaultDescription = "九州であなたに合ったお仕事を探すなら、Sugnee！";
   const defaultPath = "http://localhost/";
   const defaultImg = "/images/signup.png";
 

--- a/web/sugnee/interfaces/job.ts
+++ b/web/sugnee/interfaces/job.ts
@@ -47,16 +47,7 @@ export interface JobOffer {
   image2: string;
   image3: string;
   image4: string;
-  type_of_job: number;
-  created_at: string;
-  updated_at: string;
-}
-
-// ユーザーのお気に入り追加求人情報（一時的に定義しています）
-export interface FavoriteJobOffer {
-  id: number;
-  user_id: number;
-  corporation_joboffer_id: number;
+  type_of_job: [number];
   created_at: string;
   updated_at: string;
 }

--- a/web/sugnee/interfaces/user.ts
+++ b/web/sugnee/interfaces/user.ts
@@ -1,13 +1,13 @@
-import { FavoriteJobOffer } from "./job";
+import { JobOffer } from "./job";
 export interface User {
   id: number;
-  appliedJobs: { friku: [FavoriteJobOffer]; om: [FavoriteJobOffer] };
+  appliedJobs: { friku: [JobOffer]; om: [JobOffer] };
   applied_at: string;
   birth: string;
   created_at: string;
   email: string;
   email_verified_at: string;
-  favorites: { friku: [FavoriteJobOffer]; om: [FavoriteJobOffer] };
+  favorites: { friku: [JobOffer]; om: [JobOffer] };
   first_name: string;
   first_name_kana: string;
   gender: number;

--- a/web/sugnee/interfaces/user.ts
+++ b/web/sugnee/interfaces/user.ts
@@ -1,7 +1,7 @@
 import { FavoriteJobOffer } from "./job";
 export interface User {
   id: number;
-  appliedJobs: [];
+  appliedJobs: { friku: [FavoriteJobOffer]; om: [FavoriteJobOffer] };
   applied_at: string;
   birth: string;
   created_at: string;

--- a/web/sugnee/pages/apply/[id].tsx
+++ b/web/sugnee/pages/apply/[id].tsx
@@ -25,7 +25,7 @@ const apply: NextPage<{ job: JobOffer }> = ({ job }) => {
 
     // Fリク求人応募ロジックは仕様確定後
     // OM求人応募仮ロジック
-    if (job.type_of_job === 2) {
+    if (job.type_of_job[0] === 2) {
       await applyOmJobOffer;
       return;
     }
@@ -107,13 +107,13 @@ const apply: NextPage<{ job: JobOffer }> = ({ job }) => {
               </tbody>
             </table>
           </div>
-          {job.type_of_job === 0 && (
+          {job.type_of_job[0] === 0 && (
             <p className="text-warning my-6">
               この求人はキャリアアドバイザー面談が必要です
             </p>
           )}
           {/* 一覧から外部リンクへとばすようなら分岐を削除 */}
-          {job.type_of_job === 3 ? (
+          {job.type_of_job[0] === 3 ? (
             <a
               href={job.url}
               target="_blank"

--- a/web/sugnee/pages/apply/[id].tsx
+++ b/web/sugnee/pages/apply/[id].tsx
@@ -13,7 +13,7 @@ import { User } from "../../interfaces/user";
 
 const apply: NextPage<{ job: JobOffer }> = ({ job }) => {
   const router = useRouter();
-  const { user } = useContext(AuthContext);
+  const { user, applyOmJobOffer } = useContext(AuthContext);
 
   const applyJobOffer: (
     e: React.MouseEvent,
@@ -23,23 +23,10 @@ const apply: NextPage<{ job: JobOffer }> = ({ job }) => {
     e.preventDefault();
     if (!user) alert("応募はログインが必要です");
 
+    // Fリク求人応募ロジックは仕様確定後
     // OM求人応募仮ロジック
     if (job.type_of_job === 2) {
-      await axios
-        .post(`/api/user/joboffer/om/apply/${job.id}`)
-        .then((res) => {
-          if (res.status === 201) {
-            console.log("[applyOmJoboffer]応募成功", res);
-            router.push("/apply/success");
-          } else {
-            console.log("[applyOmJoboffer]応募失敗", res.data);
-          }
-        })
-        .catch((err) => {
-          console.log("[applyOmJoboffer]応募失敗", err.response);
-          // 仮でアラート、応募済み求人をユーザー情報に保持するようになればボタンを非活性にする
-          if (err.response.status === 400) alert(err.response.data.message);
-        });
+      await applyOmJobOffer;
       return;
     }
   };
@@ -143,14 +130,14 @@ const apply: NextPage<{ job: JobOffer }> = ({ job }) => {
               応募する
             </button>
           )}
-          <div className="lg:hidden bottom-0 fixed w-full flex justify-center bg-white bg-opacity-90 px-3 pt-8 pb-2">
-            <button
-              onClick={(e) => applyJobOffer(e, user, job)}
-              className="btn btn-accent"
-            >
-              応募する
-            </button>
-          </div>
+        </div>
+        <div className="lg:hidden bottom-0 fixed w-full flex justify-center bg-white bg-opacity-90 px-3 pt-8 pb-2">
+          <button
+            onClick={(e) => applyJobOffer(e, user, job)}
+            className="btn btn-accent w-10/12"
+          >
+            応募する
+          </button>
         </div>
       </section>
     </>

--- a/web/sugnee/pages/index.tsx
+++ b/web/sugnee/pages/index.tsx
@@ -10,7 +10,6 @@ import { AuthContext } from "../contexts/Auth";
 import { SearchConditionContext } from "../contexts/SearchCondition";
 
 // Components
-import Seo from "../components/Seo";
 import OmJobCard from "../components/Card/OmJobCard";
 import PickupCard from "../components/Card/PickupCard";
 import SearchTypeCard from "../components/Card/SearchTypeCard";
@@ -65,7 +64,6 @@ const Home: NextPage<HomeProps> = ({ omJobs, pickupArticles }) => {
 
   return (
     <>
-      <Seo />
       <div>
         <section className="w-full h-96 bg-gradient-to-b from-primary to-secondary"></section>
 

--- a/web/sugnee/pages/mypage/index.tsx
+++ b/web/sugnee/pages/mypage/index.tsx
@@ -70,6 +70,9 @@ const Mypage: React.FC = () => {
         {user && currentMenu === "favorite" && (
           <MypageJobList user={user} type={"favorite"} />
         )}
+        {user && currentMenu === "apply" && (
+          <MypageJobList user={user} type={"apply"} />
+        )}
       </div>
     </div>
   );

--- a/web/sugnee/pages/mypage/index.tsx
+++ b/web/sugnee/pages/mypage/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext, useState, MouseEventHandler } from "react";
+import { useEffect, useContext, useState } from "react";
 import { useRouter } from "next/router";
 import { AuthContext } from "../../contexts/Auth/index";
 
@@ -28,11 +28,11 @@ const Mypage: React.FC = () => {
 
   return (
     <div className="flex flex-col justify-center items-center w-full px-4 pt-10">
-      <div className="mt-10 w-1/2">
+      <div className="mt-10 w-full md:w-1/2">
         <button
           type="button"
           id="profile"
-          className={`text-sm text-gray-400 py-4 w-1/4 rounded-t-lg ${
+          className={`text-xs md:text-sm text-gray-400 py-4 w-1/3 rounded-t-lg ${
             currentMenu === "profile" && "text-gray-900 bg-gray-100"
           }`}
           onClick={handleClickMenu}
@@ -43,7 +43,7 @@ const Mypage: React.FC = () => {
         <button
           type="button"
           id="favorite"
-          className={`text-sm text-gray-400 py-4 w-1/4 rounded-t-lg ${
+          className={`text-xs md:text-sm text-gray-400 py-4 w-1/3 rounded-t-lg ${
             currentMenu === "favorite" && "text-gray-900 bg-gray-100"
           }`}
           onClick={handleClickMenu}
@@ -54,7 +54,7 @@ const Mypage: React.FC = () => {
         <button
           type="button"
           id="apply"
-          className={`text-sm text-gray-400 py-4 w-1/4 rounded-t-lg ${
+          className={`text-xs md:text-sm text-gray-400 py-4 w-1/3 rounded-t-lg ${
             currentMenu === "apply" && "text-gray-900 bg-gray-100"
           }`}
           onClick={handleClickMenu}
@@ -63,7 +63,7 @@ const Mypage: React.FC = () => {
           応募済み求人
         </button>
       </div>
-      <div className="flex flex-col justify-center items-center w-10/12 bg-gray-100 p-10 rounded-lg">
+      <div className="flex flex-col justify-center items-center w-full md:w-10/12 bg-gray-100 p-10 -mt-1 rounded-lg">
         {user && currentMenu === "profile" && (
           <Profile user={user} updateProfile={updateProfile} />
         )}

--- a/web/sugnee/pages/mypage/index.tsx
+++ b/web/sugnee/pages/mypage/index.tsx
@@ -27,7 +27,7 @@ const Mypage: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col justify-center items-center w-full px-4 pt-10">
+    <div className="flex flex-col justify-center items-center w-full pt-10">
       <div className="mt-10 w-full md:w-1/2">
         <button
           type="button"
@@ -63,7 +63,7 @@ const Mypage: React.FC = () => {
           応募済み求人
         </button>
       </div>
-      <div className="flex flex-col justify-center items-center w-full md:w-10/12 bg-gray-100 p-10 -mt-1 rounded-lg">
+      <div className="flex flex-col justify-center items-center w-full bg-gray-100 p-10 -mt-1 rounded-lg">
         {user && currentMenu === "profile" && (
           <Profile user={user} updateProfile={updateProfile} />
         )}

--- a/web/sugnee/pages/mypage/index.tsx
+++ b/web/sugnee/pages/mypage/index.tsx
@@ -4,6 +4,7 @@ import { AuthContext } from "../../contexts/Auth/index";
 
 // Components
 import Profile from "../../components/Profile";
+import MypageJobList from "../../components/MypageJobList";
 
 // Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -27,7 +28,6 @@ const Mypage: React.FC = () => {
 
   return (
     <div className="flex flex-col justify-center items-center w-full px-4 pt-10">
-
       <div className="mt-10 w-1/2">
         <button
           type="button"
@@ -66,6 +66,9 @@ const Mypage: React.FC = () => {
       <div className="flex flex-col justify-center items-center w-10/12 bg-gray-100 p-10 rounded-lg">
         {user && currentMenu === "profile" && (
           <Profile user={user} updateProfile={updateProfile} />
+        )}
+        {user && currentMenu === "favorite" && (
+          <MypageJobList user={user} type={"favorite"} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## 内容
 - https://github.com/local-venture-group/Sugnee/issues/65#issue-1058192071
 - https://github.com/local-venture-group/Sugnee/issues/90#issue-1063299627
 
## 動作確認
user1でログイン後、`http://localhost/mypage`にアクセスし、プロフィール画像とお気に入り求人＆応募済み求人が表示されることを確認してください。

<img width="1451" alt="スクリーンショット 2021-12-01 21 01 22" src="https://user-images.githubusercontent.com/65808877/144231048-9357fb7d-80de-4c89-a30e-775a235707cb.png">

<img width="1422" alt="スクリーンショット 2021-12-01 21 01 27" src="https://user-images.githubusercontent.com/65808877/144231085-fc5cd667-5695-4dae-8864-e50309b9c168.png">

※応募済み求人クリック後にconsoleに出るエラーは、user1の応募済み求人に同じ求人が3つ入っているためなので問題ありません😃