### PR TITLE
indexで入れてる求人カラムの名前文字列変換

### DIFF
--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -114,7 +114,10 @@ class UserController extends Controller
                 $filePath = $imageService->uploadBase64Image($imageFile, $folderName);
             }
             // $user->update(['img_path' => $filePath ]);
-
+            if (app()->environment('local')) {
+                $awsLocalPath = config('app.aws_access_bucket') . '.s3.' . config('app.aws_default_region') . '.amazonaws.com';
+                $filePath =  $awsLocalPath . $filePath;
+            }
         } else {
             $imageFile = $request->image;
             if (!is_null($imageFile) && $imageFile->isValid()) {
@@ -123,9 +126,7 @@ class UserController extends Controller
             // $user->update(['img_path' => $filePath ]);
         }
 
-        if (app()->environment('local')) {
-            $filePath = config('app.aws_access_bucket') . '.s3.' . config('app.aws_default_region') . '.amazonaws.com' . $filePath;
-        }
+
         $user->fill($request->validated() +  ['img_path' => $filePath])->save();
 
         return $user;

--- a/api/app/Http/Resources/JobResource.php
+++ b/api/app/Http/Resources/JobResource.php
@@ -54,7 +54,7 @@ class JobResource extends JsonResource
             "prefecture" => $this->resource->prefecture,
             "city" => $this->resource->city,
             "building" => $this->resource->building,
-            "salary_pattern" => $this->resource->salary_pattern,
+            "salary_pattern" => JobConditionConsts::SALARY_PATTERN[$this->resource->salary_pattern] ,
             "salary_min" => $this->resource->salary_min,
             "salary_max" => $this->resource->salary_max,
             "salary_description" => $this->resource->salary_description,

--- a/api/app/Services/JobService.php
+++ b/api/app/Services/JobService.php
@@ -12,7 +12,7 @@ class JobService {
         });
         return $city;
     }
-    public static function changeIntToStringType($jobs)
+    public  function convertStringName($jobs)
     {
 
         $job = collect($jobs)->each(function ($job) {

--- a/api/app/Services/JobService.php
+++ b/api/app/Services/JobService.php
@@ -12,4 +12,30 @@ class JobService {
         });
         return $city;
     }
+    public static function changeIntToStringType($jobs)
+    {
+
+        $job = collect($jobs)->each(function ($job) {
+
+            $job->work_type = isset($job->work_type)
+                ? JobConditionConsts::WORK_TYPES[$job->work_type]
+                : '';
+            $job->job_type = isset($job->job_type)
+                ? JobConditionConsts::JOB_TYPES[$job->job_type]
+                : '';
+            $job->hiring_system = isset($job->hiring_system) && array_key_exists($job->hiring_system, JobConditionConsts::HIRING_SYSTEMS)
+                ? JobConditionConsts::HIRING_SYSTEMS[$job->hiring_system]
+                : '';
+            $job->salary_pattern = isset($job->salary_pattern)
+                ? JobConditionConsts::SALARY_PATTERN[$job->salary_pattern]
+                : '';
+            $job->trial = isset($job->traial)
+                ? JobConditionConsts::TRIALS[$job->traial]
+                : '';
+            $job->travel_cost = isset($job->travel_cost)
+                ? JobConditionConsts::TRAVEL_COSTS[$job->travel_cost]
+                : '';
+        });
+        return $job;
+    }
 }

--- a/api/app/Services/UserService.php
+++ b/api/app/Services/UserService.php
@@ -6,17 +6,24 @@ use App\Models\CorporationApplicantschedule;
 use App\Models\CorporationJoboffer;
 use App\Models\Favorite;
 use App\Models\User;
-
+use App\Services\JobService;
 class UserService
 {
+    public function __construct()
+    {
+        $this->jobService = new JobService();
+    }
     public function getOmFavorited(User $user)
     {
+
         $omfavorites = Favorite::where('user_id', $user->id)->get();
 
         $favoritesOmBaseJobs = CorporationJoboffer::whereIn('id', $omfavorites->pluck('corporation_joboffer_id'))->get();
         $favoritesOmBaseJobs->each(function ($job){
             $job->append('type_of_job');
         });
+
+        $favoritesOmBaseJobs = $this->jobService->convertStringName($favoritesOmBaseJobs);
         return  ['om' => $favoritesOmBaseJobs];
     }
     public function getFrikuFavorited(User $withUser)
@@ -25,6 +32,7 @@ class UserService
         $favoritesFrikuBaseJobs->each(function ($job){
             $job->append('type_of_job');
         });
+        $favoritesFrikuBaseJobs = $this->jobService->convertStringName($favoritesFrikuBaseJobs);
         return ['friku' => $favoritesFrikuBaseJobs];
     }
     public function getOmApplied(User $user)
@@ -42,6 +50,7 @@ class UserService
                 $omJoboffer->each(function ($job){
                     $job->append('type_of_job');
                 });
+                $omJoboffer = $this->jobService->convertStringName($omJoboffer);
                 $applied['om'] = $omJoboffer;
             }
         return $applied;
@@ -58,6 +67,7 @@ class UserService
             $frikuJoboffer->each(function ($job){
                 $job->append('type_of_job');
             });
+            $frikuJoboffer = $this->jobService->convertStringName($frikuJoboffer);
             $applied['friku'] = $frikuJoboffer;
         }
         return $applied;

--- a/web/sugnee/components/Card/OmJobCard/index.tsx
+++ b/web/sugnee/components/Card/OmJobCard/index.tsx
@@ -68,7 +68,8 @@ const OmJobCard: React.FC<OmJobCardProps> = ({ job, user, userFavorites }) => {
               <FontAwesomeIcon icon={faYenSign} />
               <span className="text-gray-500 text-sm ml-3">
                 {job.salary_pattern}
-                {job.salary_min}円〜{job.salary_max}円
+                {parseInt(job.salary_min).toLocaleString()}円〜
+                {parseInt(job.salary_max).toLocaleString()}円
               </span>
             </li>
           </ul>

--- a/web/sugnee/components/Card/PickupJobCard/index.tsx
+++ b/web/sugnee/components/Card/PickupJobCard/index.tsx
@@ -76,7 +76,8 @@ export const PickupJobCard: React.FC<PickupJobCardProps> = ({
               <FontAwesomeIcon icon={faYenSign} />
               <span className="text-gray-500 text-sm ml-3">
                 {job.salary_pattern}
-                {job.salary_min}円〜{job.salary_max}円
+                {parseInt(job.salary_min).toLocaleString()}円〜
+                {parseInt(job.salary_max).toLocaleString()}円
               </span>
             </li>
           </ul>

--- a/web/sugnee/pages/job/[id]/index.tsx
+++ b/web/sugnee/pages/job/[id]/index.tsx
@@ -22,8 +22,8 @@ import { JobOffer } from "../../../interfaces/job";
 const jobOffer: NextPage<{ job: JobOffer }> = ({ job }) => {
   const router = useRouter();
   const { user, addOmBookmark, deleteOmBookmark } = useContext(AuthContext);
-  const userFavorites: number[] = user?.favorites.friku.map(
-    (favoriteJob) => favoriteJob.corporation_joboffer_id
+  const userFavorites: number[] = user?.favorites.om.map(
+    (favoriteJob) => favoriteJob.id
   );
 
   const applyJobOffer = (): void => {


### PR DESCRIPTION
**プルリクの報告後、13:29に上げ忘れコミットを発見し、追加pushしております！**
## 作業内容
- https://github.com/local-venture-group/Sugnee/issues/121
- 求人の各種intで管理しているデータをreturn前に文字列に型変換
- 別件にはなりますが、mypageの編集時、画像を指定しなかったときのurlがおかしくなる問題
## 動作確認
- `http://localhost/`で表示されている新着求人や、`http://localhost/pickup/hwhgev8xb`　にアクセスして、出てくるピックアップ記事求人の給与欄の部分の月給や年収等の名前でがきちんと表示されているか。
- `http://localhost/mypage`にアクセスし、お気に入り求人タブや応募済求人タブをクリックし、中の求人の各種データがちゃんとindexから文字列の各種データ名として表示されているか。
- 
- ①プロフィールタブにて、１回適当な画像を入れてアップロードする。　②その後、マイページのプロフィールが切り替わった後、名前等画像と関係ない項目を編集し、画像はそのままで、変更するボタンを押す。③画像がそのまま表示された状態で、変更項目は更新されているか。

以上問題なければ動作確認終了です。
<img width="517" alt="スクリーンショット 2021-12-02 12 48 40" src="https://user-images.githubusercontent.com/61079243/144357367-06fc4671-34a4-475a-b681-fbe8d6308905.png">
<img width="1064" alt="スクリーンショット 2021-12-02 12 53 35" src="https://user-images.githubusercontent.com/61079243/144357383-ae39cb8c-df52-40ad-9572-00f6e00ca488.png">
