### PR TITLE
ユーザーお気に入り、応募済みの求人に作成日付与

### DIFF
--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -103,7 +103,7 @@ class UserController extends Controller
 
         $filePath = $user->img_path;
         $folderName = 'users';
-        if ($request->has('imageBase64')) {
+        if ($request->has('imageBasema64')) {
             $request->validate([
                 'image' => 'nullable|string',
             ]);

--- a/api/app/Http/Controllers/Api/User/UserController.php
+++ b/api/app/Http/Controllers/Api/User/UserController.php
@@ -103,7 +103,7 @@ class UserController extends Controller
 
         $filePath = $user->img_path;
         $folderName = 'users';
-        if ($request->has('imageBasema64')) {
+        if ($request->has('imageBase64')) {
             $request->validate([
                 'image' => 'nullable|string',
             ]);

--- a/api/app/Models/Favorite.php
+++ b/api/app/Models/Favorite.php
@@ -14,6 +14,9 @@ class Favorite extends Model
     protected $connection = 'fukuriku';
     protected $fillable = ['user_id', 'corporation_joboffer_id'];
 
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
     public function users() : belongsTo
     {
         return $this->belongsTo(User::class);

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use App\Models\CorporationJoboffer;
 use App\Models\MessageRoom;
 use App\Notifications\PasswordResetNotification;
+use Carbon\Carbon;
 
 class User extends Authenticatable
 {
@@ -57,7 +58,7 @@ class User extends Authenticatable
     {
         $this->notify(new PasswordResetNotification($token));
     }
-    //複数DBの使用だと、BelongsToManyが使えないので, HasManyに変更。
+    //複数DBの使用をまたぐと、BelongsToManyが使えないので, HasManyに変更。
     public function favorites()
     {
         return $this->hasMany(Favorite::class, 'user_id');
@@ -81,7 +82,9 @@ class User extends Authenticatable
     }
     public function frikuFavorites()
     {
-        return $this->belongsToMany(FrikuJoboffer::class, 'friku_favorites');
+        return $this
+            ->belongsToMany(FrikuJoboffer::class, 'friku_favorites')
+            ->withPivot(['created_at', 'updated_at', 'id']);
     }
     public function corporationApplicant()
     {
@@ -90,7 +93,9 @@ class User extends Authenticatable
     public function frikuApplicant()
     {
         return $this->hasOne(FrikuApplicant::class, 'user_id');
+
     }
+
 
 
 }

--- a/api/app/Services/UserService.php
+++ b/api/app/Services/UserService.php
@@ -12,9 +12,14 @@ class UserService
     public function getOmFavorited(User $user)
     {
         $omfavorites = Favorite::where('user_id', $user->id)->get();
-
-        $favoritesOmBaseJobs = CorporationJoboffer::whereIn('id', $omfavorites->pluck('corporation_joboffer_id'))->get();
-        $favoritesOmBaseJobs->each(function ($job){
+        $omfavoritesIds = $omfavorites->pluck('corporation_joboffer_id');
+        $favoritesOmBaseJobs = CorporationJoboffer::whereIn('id', $omfavoritesIds )->get();
+        $favoritesOmBaseJobs->each(function ($job) use ($omfavoritesIds, $omfavorites) {
+            foreach($omfavoritesIds as $omfavoritesId) {
+                if ($job->id === $omfavoritesId) {
+                    $job->favorites_created_at = $omfavorites->where('corporation_joboffer_id', $omfavoritesId)->first()->created_at->toDateTimeString();
+                }
+            }
             $job->append('type_of_job');
         });
         return  ['om' => $favoritesOmBaseJobs];
@@ -23,6 +28,7 @@ class UserService
     {
         $favoritesFrikuBaseJobs = $withUser->frikuFavorites;
         $favoritesFrikuBaseJobs->each(function ($job){
+            $job->favorites_created_at = $job->pivot->created_at->toDateTimeString();
             $job->append('type_of_job');
         });
         return ['friku' => $favoritesFrikuBaseJobs];
@@ -39,7 +45,8 @@ class UserService
 
                     return $schedule->corporationJoboffer;
                 });
-                $omJoboffer->each(function ($job){
+                $omJoboffer->each(function ($job) use ($applicantWithApplied){
+                    $job->applied_at = $applicantWithApplied->where('job_offer_id', $job->id)->first()->applied_at;
                     $job->append('type_of_job');
                 });
                 $applied['om'] = $omJoboffer;
@@ -55,7 +62,8 @@ class UserService
             $frikuJoboffer = collect($frikuApplicant->frikuApplicantSchedules)->map(function ($schedule, $key) {
                 return $schedule->frikuJoboffer;
             });
-            $frikuJoboffer->each(function ($job){
+            $frikuJoboffer->each(function ($job) use ($frikuApplicant){
+                $job->applied_at = $frikuApplicant->frikuApplicantSchedules->where('friku_joboffer_id', $job->id)->first()->applied_at;
                 $job->append('type_of_job');
             });
             $applied['friku'] = $frikuJoboffer;

--- a/api/config/database.php
+++ b/api/config/database.php
@@ -58,6 +58,7 @@ return [
             'schema' => 'public',
             'sslmode' => 'prefer',
             'schema' => 'public',
+            'timezone' => 'Asia/Tokyo',
         ],
         'ats' => [
             'driver' => 'pgsql',
@@ -71,7 +72,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-
+            'timezone' => 'Asia/Tokyo',
             'sslmode' => 'prefer',
             'schema' => 'public',
 

--- a/api/database/factories/CorporationApplicantScheduleFactory.php
+++ b/api/database/factories/CorporationApplicantScheduleFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\CorporationApplicant;
 use App\Models\CorporationApplicantSchedule;
 use App\Models\CorporationJoboffer;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -24,13 +25,13 @@ class CorporationApplicantScheduleFactory extends Factory
      */
     public function definition()
     {
+        $carbon = new Carbon();
         return [
             'job_offer_id' => $this->faker->unique()->numberBetween(1, 4),
             'applicant_id' => 1,
             'temp_id' => Str::uuid(),
             'status' => $this->faker->numberBetween(1, 2),
-            'applied_at' => now(),
-
+            'applied_at' => $carbon->subDays(rand(1, 10))
         ];
     }
 }

--- a/api/database/factories/FrikuApplicantFactory.php
+++ b/api/database/factories/FrikuApplicantFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\FrikuApplicant;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -22,6 +23,7 @@ class FrikuApplicantFactory extends Factory
      */
     public function definition()
     {
+        $carbon = new Carbon();
         return [
             'temp_id' => Str::uuid(),
             'is_registered' => $this->faker->boolean(50),
@@ -33,7 +35,7 @@ class FrikuApplicantFactory extends Factory
             'phone' => $this->faker->phoneNumber,
             'email' => $this->faker->unique()->safeEmail,
             'applicant_gender' => $this->faker->numberBetween(1,2),
-            'applied_at' => now(),
+            'applied_at' => $carbon->subDays(random_int(1, 10)),
             'user_id' => 1,
         ];
     }

--- a/api/database/factories/FrikuApplicantscheduleFactory.php
+++ b/api/database/factories/FrikuApplicantscheduleFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\FrikuApplicantschedule;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -22,12 +23,13 @@ class FrikuApplicantscheduleFactory extends Factory
      */
     public function definition()
     {
+        $carbon = new Carbon();
         return [
             'friku_joboffer_id' => 1,
             'friku_applicant_id' => 1,
             'temp_id' => Str::uuid(),
             'status' => $this->faker->numberBetween(1, 2),
-            'applied_at' => now(),
+            'applied_at' => $carbon->subDays(rand(1, 30))
         ];
     }
 }

--- a/api/database/migrations/2021_12_03_113901_drop_column_applied_at_column.php
+++ b/api/database/migrations/2021_12_03_113901_drop_column_applied_at_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropColumnAppliedAtColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('applied_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('applied_at')->nullable();
+        });
+    }
+}

--- a/api/database/seeders/FavoritesSeeder.php
+++ b/api/database/seeders/FavoritesSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -15,11 +16,14 @@ class FavoritesSeeder extends Seeder
      */
     public function run()
     {
+        $carbon = new Carbon;
         for($i = 1; $i <= 3; $i++) {
             DB::table('favorites')->insert([
                 'id' => $i,
                 'user_id' => 1,
                 'corporation_joboffer_id' => $i,
+                'created_at' => $carbon->subDays(rand(1, 10)),
+                'updated_at' => now()
             ]);
         }
 

--- a/api/database/seeders/FrikuFavoritesSeeder.php
+++ b/api/database/seeders/FrikuFavoritesSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -14,6 +15,7 @@ class FrikuFavoritesSeeder extends Seeder
      */
     public function run()
     {
+        $carbon = new Carbon();
         for ($i = 1; $i <= 3; $i++) {
             DB::table('friku_favorites')->insert([
 
@@ -21,6 +23,8 @@ class FrikuFavoritesSeeder extends Seeder
                     'id' => $i,
                     'friku_joboffer_id' => $i,
                     'user_id' => 1,
+                    'created_at' => $carbon->subDays(random_int(1,10)),
+                    'updated_at' => now(),
                 ],
 
             ]);


### PR DESCRIPTION
## 作業内容
- https://github.com/local-venture-group/Sugnee/issues/124
- ユーザー情報に合わせて返す、お気に入り求人、応募済求人に作成日カラムを追加
- 応募系は`applied_at` , お気に入り系は `favorites_created_at`
- 時間をバラバラにするために、seedファイル, factoryクラスの修正。
## 動作確認
- 作成日に時間差がでるように、テストデータを変更しております。backコンテナに入った後、`php artisan migrate:refresh --seed` コマンドを実行してください。
- `http://localhost/login`から メアド`user1@example.com` パスワード`password` でログイン後、user情報のappliedJobsの中にある求人に、`applied_at`, favoritesの中にある求人に、`favorites_created_at`が存在しており、それぞれdatetimeで入っていれば動作確認完了です
<img width="1230" alt="スクリーンショット 2021-12-02 18 23 02" src="https://user-images.githubusercontent.com/61079243/144393825-571be85e-23e0-4b09-b382-0ef11ca169bf.png">
。